### PR TITLE
[Feature/#28]: Reward 컴포넌트 애니매이션 수정하기

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,39 +1,9 @@
-'use client'
-import { useState } from 'react'
-import Reward from '@/components/common/Reward'
-
-export default function Test() {
-  const [isShowReward, setIsShowReward] = useState(false)
-
-  const handleShowReward = () => {
-    setIsShowReward(true)
-  }
-
-  const handleCloseReward = () => {
-    setIsShowReward(false)
-  }
-
+export default function page() {
   return (
     <>
-      {!isShowReward && (
-        <button
-          onClick={handleShowReward}
-          className="mb-4 px-4 py-2 bg-blue-500 text-white rounded"
-        >
-          보상 받기
-        </button>
-      )}
-      {isShowReward && (
-        <Reward
-          onClose={handleCloseReward}
-          yaho="앗, 아쉬워~"
-          rewardContent={
-            <span>
-              퀴즈는 틀렸지만 <span className="text-mint-green">치료약 1개</span>를 획득했다!
-            </span>
-          }
-        />
-      )}
+      <div className="font-admin">Admin 폰트로 설정된 텍스트</div>
+      <div className="font-user-m">User M 폰트로 설정된 텍스트</div>
+      <div className="font-user-b">User B 폰트로 설정된 텍스트</div>
     </>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,39 @@
-export default function page() {
+'use client'
+import { useState } from 'react'
+import Reward from '@/components/common/Reward'
+
+export default function Test() {
+  const [isShowReward, setIsShowReward] = useState(false)
+
+  const handleShowReward = () => {
+    setIsShowReward(true)
+  }
+
+  const handleCloseReward = () => {
+    setIsShowReward(false)
+  }
+
   return (
     <>
-      <div className="font-admin">Admin 폰트로 설정된 텍스트</div>
-      <div className="font-user-m">User M 폰트로 설정된 텍스트</div>
-      <div className="font-user-b">User B 폰트로 설정된 텍스트</div>
+      {!isShowReward && (
+        <button
+          onClick={handleShowReward}
+          className="mb-4 px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          보상 받기
+        </button>
+      )}
+      {isShowReward && (
+        <Reward
+          onClose={handleCloseReward}
+          yaho="앗, 아쉬워~"
+          rewardContent={
+            <span>
+              퀴즈는 틀렸지만 <span className="text-mint-green">치료약 1개</span>를 획득했다!
+            </span>
+          }
+        />
+      )}
     </>
   )
 }

--- a/src/components/common/Reward.tsx
+++ b/src/components/common/Reward.tsx
@@ -32,7 +32,7 @@ export default function Reward(props: RewardProps) {
 
   return (
     <div
-      className={`relative w-screen h-screen ${
+      className={`relative h-screen ${
         isFadingOut ? 'animate-scale-out-center-slow' : 'animate-scale-in-center-slow'
       }`}
       onAnimationEnd={handleAnimationEnd}

--- a/src/components/common/Reward.tsx
+++ b/src/components/common/Reward.tsx
@@ -32,7 +32,7 @@ export default function Reward(props: RewardProps) {
       } `}
       onAnimationEnd={handleAnimationEnd}
     >
-      <Image src="/image/reward_background.svg" alt="" width={390} height={500} />
+      <Image src="/image/reward_background.svg" alt="" layout="fill" objectFit="cover" />
       <div className="absolute inset-0 flex flex-col items-center justify-center">
         <Image src="/image/reward.svg" alt="" width={110} height={110} className="mb-[25px]" />
         <RewardText yaho={yaho} onScaleOutStart={handleRewardTextScaleOutStart}>

--- a/src/components/common/Reward.tsx
+++ b/src/components/common/Reward.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 import RewardText from './RewardText'
@@ -7,40 +7,37 @@ import { RewardProps } from '@/types/Reward'
 
 export default function Reward(props: RewardProps) {
   const router = useRouter()
-  const [isShowReward, setIsShowReward] = useState(true)
-  const [isFadingOut, setIsFadingOut] = useState(false)
+  const [isRewardScaleOut, setIsRewardScaleOut] = useState(false) // Reward가 사라지는 상태
 
   const { yaho, rewardContent, onClose } = props
 
-  useEffect(() => {
-    const timer: NodeJS.Timeout = setTimeout(() => {
-      setIsFadingOut(true)
-    }, 2000)
-
-    return () => clearTimeout(timer)
-  }, [onClose, router])
+  // RewardText가 사라지기 시작하면 일정 시간 후 Reward도 사라지도록
+  const handleRewardTextScaleOutStart = () => {
+    setTimeout(() => {
+      setIsRewardScaleOut(true)
+    }, 100)
+  }
 
   const handleAnimationEnd = () => {
-    if (isFadingOut) {
-      setIsShowReward(false)
+    if (isRewardScaleOut) {
       router.push('/')
       onClose?.()
     }
   }
 
-  if (!isShowReward) return null
-
   return (
     <div
       className={`relative h-screen ${
-        isFadingOut ? 'animate-scale-out-center-slow' : 'animate-scale-in-center-slow'
-      }`}
+        isRewardScaleOut ? 'animate-scale-out-center-slow' : 'animate-scale-in-center-slow'
+      } `}
       onAnimationEnd={handleAnimationEnd}
     >
-      <Image src="/image/reward_background.svg" alt="" width={390} height={110} />
+      <Image src="/image/reward_background.svg" alt="" width={390} height={500} />
       <div className="absolute inset-0 flex flex-col items-center justify-center">
         <Image src="/image/reward.svg" alt="" width={110} height={110} className="mb-[25px]" />
-        <RewardText yaho={yaho}>{rewardContent}</RewardText>
+        <RewardText yaho={yaho} onScaleOutStart={handleRewardTextScaleOutStart}>
+          {rewardContent}
+        </RewardText>
       </div>
     </div>
   )

--- a/src/components/common/Reward.tsx
+++ b/src/components/common/Reward.tsx
@@ -37,7 +37,7 @@ export default function Reward(props: RewardProps) {
       }`}
       onAnimationEnd={handleAnimationEnd}
     >
-      <Image src="/image/reward_background.svg" alt="" fill />
+      <Image src="/image/reward_background.svg" alt="" width={390} height={110} />
       <div className="absolute inset-0 flex flex-col items-center justify-center">
         <Image src="/image/reward.svg" alt="" width={110} height={110} className="mb-[25px]" />
         <RewardText yaho={yaho}>{rewardContent}</RewardText>

--- a/src/components/common/RewardText.tsx
+++ b/src/components/common/RewardText.tsx
@@ -1,11 +1,28 @@
 import Image from 'next/image'
+import { useEffect, useState } from 'react'
 import { Text } from '@/types/TextField'
 
-export default function RewardText(props: Text) {
-  const { yaho = '야호~!', children } = props
+export default function RewardText(props: Text & { onScaleOutStart?: () => void }) {
+  const [isRewardTextScaleOut, setIsRewardTextScaleOut] = useState(false)
+
+  const { yaho = '야호~!', children, onScaleOutStart } = props
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsRewardTextScaleOut(true) // 스케일 아웃 애니메이션 시작
+      onScaleOutStart?.() // 부모 컴포넌트에 애니메이션 시작 알림
+    }, 2000)
+
+    return () => clearTimeout(timer)
+  }, [])
 
   return (
-    <div className="animate-scale-in-center flex flex-col items-center">
+    <div
+      className={`flex flex-col items-center  ${
+        isRewardTextScaleOut ? 'animate-scale-out-center' : 'animate-scale-in-center'
+      }
+      `}
+    >
       <div className="w-[330px] h-[100px] bg-beige flex items-center justify-center rounded-[40px]">
         <p className="cursor-default text-[16px] font-sindinaru-b text-brown text-center leading-5 tracking-[-0.24px]">
           {yaho}

--- a/src/components/common/RewardText.tsx
+++ b/src/components/common/RewardText.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
-import { Text } from '@/types/TextField'
+import { RewardTextProps } from '@/types/TextField'
 
-export default function RewardText(props: Text & { onScaleOutStart?: () => void }) {
+export default function RewardText(props: RewardTextProps) {
   const [isRewardTextScaleOut, setIsRewardTextScaleOut] = useState(false)
 
   const { yaho = '야호~!', children, onScaleOutStart } = props

--- a/src/types/TextField.ts
+++ b/src/types/TextField.ts
@@ -2,3 +2,7 @@ export interface Text {
   yaho?: string
   children: React.ReactNode
 }
+
+export type RewardTextProps = Text & {
+  onScaleOutStart?: () => void
+}


### PR DESCRIPTION
### 🖼️ Screen shot

| Reward | RewardText |
| :-------------: | :-------------: |
| ![reward](https://github.com/user-attachments/assets/4261f14e-4baf-415f-a4b8-8262f312d3fa)  |  ![rewardtext](https://github.com/user-attachments/assets/6966020a-2eb5-4f5f-9421-c6da163a822c) |


### ✅ 작업 내용

- Reward 컴포넌트에서 RewardText 컴포넌트 먼저 사라지게 하고 사라지도록 구현
- Reward, RewardText 컴포넌트가 사라지는 시점은 다르지만 화면에 안보일때는 동일하게 구현
- RewardText 컴포넌트 사라지는 애니매이션 및 `onScaleOutStart` prop 추가

### 📝 Details

- `RewardText` 컴포넌트에 2초 후 스케일 아웃 애니메이션이 시작되도록 설정했습니다. 애니메이션이 시작되면 `onScaleOutStart` 콜백을 통해 상위 컴포넌트인 `Reward`에 알립니다.
- `Reward` 컴포넌트는 `RewardText`의 애니메이션이 시작된 후 약간의 딜레이(100ms)를 두고 함께 스케일 아웃 애니메이션을 시작하여, 두 컴포넌트가 화면에서 동시에 사라지도록 구현했습니다.
- 컴포넌트가 사라지는 타이밍을 맞추기 위해 `isRewardScaleOut`와 `isRewardTextScaleOut` 상태 변수를 각각 설정하여 독립적으로 관리하였으며, 애니메이션 클래스 조건부 렌더링을 통해 스케일 인/아웃을 제어했습니다.


### 💬 Notice

- 전에 pr에 예시 코드 있어서 여기서는 안쓰고 애니매이션 관련된 내용만 작성했습니다. 
