### PR TITLE
feat(feature/#27): 모달 커스텀훅 및 모달 컴포넌트 생성

### DIFF
--- a/src/app/hook/useModal.ts
+++ b/src/app/hook/useModal.ts
@@ -24,7 +24,7 @@ const allowScroll = (prevScrollY: number) => {
 const useModal = (): UseModalReturn => {
   const [isOpen, setIsOpen] = useState(false)
   const [portalElement, setPortalElement] = useState<Element | null>(null)
-  const [scrollPosition, setScrollPosition] = useState<number>(0) //
+  const [scrollPosition, setScrollPosition] = useState<number>(0)
 
   const openModal = useCallback(() => {
     const scrollY = preventScroll() // 스크롤 위치 저장

--- a/src/app/hook/useModal.ts
+++ b/src/app/hook/useModal.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+type UseModalReturn = [boolean, () => void, () => void, Element | null]
+
+const preventScroll = () => {
+  const currentScrollY = window.scrollY
+  document.body.style.position = 'fixed'
+  document.body.style.width = '100%'
+  document.body.style.top = `-${currentScrollY}px`
+  document.body.style.overflowY = 'scroll'
+  return currentScrollY
+}
+
+const allowScroll = (prevScrollY: number) => {
+  document.body.style.position = ''
+  document.body.style.width = ''
+  document.body.style.top = ''
+  document.body.style.overflowY = ''
+  window.scrollTo(0, prevScrollY)
+}
+
+const useModal = (): UseModalReturn => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [portalElement, setPortalElement] = useState<Element | null>(null)
+  const [scrollPosition, setScrollPosition] = useState<number>(0) //
+
+  const openModal = useCallback(() => {
+    const scrollY = preventScroll() // 스크롤 위치 저장
+    setScrollPosition(scrollY)
+    setIsOpen(true)
+  }, [])
+
+  const closeModal = useCallback(() => {
+    allowScroll(scrollPosition)
+    setIsOpen(false)
+  }, [scrollPosition])
+
+  useEffect(() => {
+    setPortalElement(document.getElementById('portal'))
+  }, [])
+
+  return [isOpen, openModal, closeModal, portalElement]
+}
+
+export default useModal

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,9 +15,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body suppressHydrationWarning={true} className="flex items-center justify-center">
-        <div className="max-w-[390px] w-screen h-screen bg-light-beige">
+        <div className="max-w-[390px] w-screen h-screen bg-light-beige relative">
           <HeaderLayout />
           {children}
+          <div id="portal"></div>
         </div>
       </body>
     </html>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+interface ModalProps {
+  children: React.ReactNode
+  height: number
+  onClick?: () => void // 모달 닫기 함수
+}
+
+export default function Modal(props: ModalProps) {
+  const { children, height, onClick } = props
+
+  return (
+    <>
+      <div
+        className="w-[390px] h-screen bg-black opacity-25 z-100000 absolute top-0 left-0 flex justify-center items-center"
+        onClick={onClick}
+      ></div>
+
+      <div
+        style={{ height: `${height}px` }}
+        className="w-[313px] rounded-[30px] bg-light-beige flex justify-center items-center flex-col z-1000001 absolute top-[50%] translate-y-[-50%]"
+      >
+        {children}
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
### 🖼️ Screen shot

https://github.com/user-attachments/assets/b5598757-1706-4ec5-a17d-59eafc8f6961


### ✅ 작업 내용

- 모달 커스텀 훅 및 모달 컴포넌트 생성

### 📝 Details
- `height`로 모달의 높이 지정 후 `children`을 모달 컨텐츠로 사용합니다.
- 모달 커스텀 훅을 `import`해서 사용해야 합니다.
- 모달이 열렸을 때 백그라운드 페이지의 스크롤을 못하도록 막았습니다.

- props
  - `children`
  - `height` 

### 💻 예시코드

```jsx
'use client'

import Button from '@/components/common/Button'
import Modal from '@/components/common/Modal'
import useModal from './hook/useModal'

export default function page() {
  const [isOpen, openModal, closeModal, portalElement] = useModal()

  return (
    <div className=" p-10 flex flex-col gap-10 h-[200vh]">
      <Button width={300} height={50} fontSize={14} onClick={openModal}>
        Modal height: 273
      </Button>
      {portalElement && isOpen && (
        <Modal height={273} onClick={openModal}>
          모달 테스트~~ <br />
          <Button width={100} height={40} fontSize={12} onClick={closeModal}>
            모달 닫기
          </Button>
        </Modal>
      )}
    </div>
  )
}

```

### ⚠️ 주의사항

- 모달 오버레이 클릭 시 모달을 닫게 하려면 `onClick={closeModal}`을 작성해야 합니다.
- `closeModal` 등 모달 동작을 위한 props 내용은 예시 코드처럼 모달 커스텀 훅을 `import` 해서 사용합니다.
