### PR TITLE
modify(feature/#33): url 경로에 따라 레이아웃 배경색 지정하지 않도록 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import '@/styles/globals.css'
 import HeaderLayout from '@/components/layout/HeaderLayout'
+import BackgroundWrapper from '@/components/layout/BackgroundWrapper'
 
 export const metadata: Metadata = {
   title: '구해줘요 동물의숲',
@@ -15,10 +16,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body suppressHydrationWarning={true} className="flex items-center justify-center">
-        <div className="max-w-[390px] w-screen h-screen bg-light-beige">
+        <BackgroundWrapper>
           <HeaderLayout />
           {children}
-        </div>
+        </BackgroundWrapper>
       </body>
     </html>
   )

--- a/src/components/layout/BackgroundWrapper.tsx
+++ b/src/components/layout/BackgroundWrapper.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+interface BackgroundWrapperProps {
+  children: React.ReactNode
+}
+
+export default function BackgroundWrapper(props: BackgroundWrapperProps) {
+  const { children } = props
+
+  const pathname = usePathname()
+  const whiteBackground = ['/', '/walk', '/ranking', '/report']
+
+  return (
+    <div
+      className={`max-w-[390px] w-screen h-screen ${
+        whiteBackground.includes(pathname) ? '' : 'bg-light-beige'
+      }`}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/layout/BackgroundWrapper.tsx
+++ b/src/components/layout/BackgroundWrapper.tsx
@@ -14,7 +14,7 @@ export default function BackgroundWrapper(props: BackgroundWrapperProps) {
 
   return (
     <div
-      className={`max-w-[390px] w-screen h-screen ${
+      className={`max-w-[390px] w-screen h-screen relative ${
         whiteBackground.includes(pathname) ? '' : 'bg-light-beige'
       }`}
     >


### PR DESCRIPTION
### 🖼️ Screen shot

| 레이아웃 배경색x| 레이아웃 배경색o|
|--|--|
|![image](https://github.com/user-attachments/assets/2af59f4d-97df-4acf-9b62-1e8c3c917e15)|![image](https://github.com/user-attachments/assets/0fbe8adc-2d28-4812-bd7b-2ee03287a2ae)|




### ✅ 작업 내용

- 페이지 url에 따라 특정 페이지에서는 배경에 베이지색이 설정되지 않도록 했습니다.

### 📝 Details
```jsx
'use client'

import { usePathname } from 'next/navigation'

interface BackgroundWrapperProps {
  children: React.ReactNode
}

export default function BackgroundWrapper(props: BackgroundWrapperProps) {
  const { children } = props

  const pathname = usePathname()
  const whiteBackground = ['/', '/walk', '/ranking', '/report']

  return (
    <div
      className={`max-w-[390px] w-screen h-screen relative ${
        whiteBackground.includes(pathname) ? '' : 'bg-light-beige'
      }`}
    >
      {children}
    </div>
  )
}

```

### ⚠️ 주의사항

- 추후 url의 수정을 하거나 배경색을 지정하지 않는 페이지가 생기면 components/layout/BackgroundWrapper.tsx의 whiteBackground 배열에 수정하시면 됩니다~
