### PR TITLE
Feature/#26: 걷기 도중 걷기 종료 시 보상 안 받고 메인 페이지로 이동, 걷기 테스트 좌표 사용해서 이동경로 지도에 보이도록 하기

### DIFF
--- a/src/app/walk/page.tsx
+++ b/src/app/walk/page.tsx
@@ -9,6 +9,7 @@ import useModal from '../hook/useModal'
 import Image from 'next/image'
 import Reward from '@/components/common/Reward'
 import BottomPanel from '@/components/walk/BottomPanel'
+import { useRouter } from 'next/navigation'
 
 export type WalkType = 'initial' | 'walking' | 'stop'
 
@@ -18,6 +19,8 @@ export interface Coordinates {
 }
 
 export default function Page() {
+  const router = useRouter()
+
   const [isOpen, openModal, closeModal, portalElement] = useModal()
 
   const [isLoading, setIsLoading] = useState(true)
@@ -62,7 +65,7 @@ export default function Page() {
                 width={100}
                 height={40}
                 fontSize={12}
-                onClick={() => setIsShowReward(true)}
+                onClick={() => router.push('/')}
                 backgroundColor="bg-orange"
               >
                 걷기 종료

--- a/src/app/walk/page.tsx
+++ b/src/app/walk/page.tsx
@@ -2,7 +2,7 @@
 
 import Header from '@/components/common/header/Header'
 import WalkMap from '@/components/walk/Map'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Button from '@/components/common/Button'
 import Modal from '@/components/common/Modal'
 import useModal from '../hook/useModal'
@@ -28,6 +28,20 @@ export default function Page() {
   const [walkType, setWalkType] = useState<WalkType>('initial')
   const [isShowReward, setIsShowReward] = useState(false)
 
+  const [distance, setDistance] = useState<number>(0)
+
+  const formatDistance = (distanceInMeters: number): string => {
+    if (distanceInMeters >= 1000) {
+      // 1000m 이상인 경우, km로 변환하여 소수점 첫째 자리까지 표시
+      const distanceInKm = (distanceInMeters / 1000).toFixed(1)
+      return `${distanceInKm} km`
+    } else {
+      // 1000m 미만인 경우, 소수점 버리고 m로 표시
+      const flooredMeters = Math.floor(distanceInMeters)
+      return `${flooredMeters} m`
+    }
+  }
+
   const getReward = () => {
     setIsShowReward(false)
     closeModal()
@@ -38,12 +52,19 @@ export default function Page() {
       {isLoading || (walkType === 'initial' && <Header useReportBtn />) || (
         <Header backOnClick={openModal} />
       )}
-      <WalkMap setIsLoading={setIsLoading} location={location} setLocation={setLocation} />
+      <WalkMap
+        setIsLoading={setIsLoading}
+        location={location}
+        setLocation={setLocation}
+        walkType={walkType}
+        setDistance={setDistance}
+      />
       {isLoading || (
         <BottomPanel
           walkType={walkType}
           setWalkType={setWalkType}
           setIsShowReward={setIsShowReward}
+          distance={formatDistance(distance)}
         />
       )}
       {/* 걷기 도중 헤더 < 버튼 눌렀을 때 */}

--- a/src/components/walk/BottomPanel.tsx
+++ b/src/components/walk/BottomPanel.tsx
@@ -6,10 +6,12 @@ interface BottomPanelProps {
   walkType: WalkType
   setWalkType: React.Dispatch<React.SetStateAction<WalkType>>
   setIsShowReward: React.Dispatch<React.SetStateAction<boolean>>
+  distance: string
 }
 
 export default function BottomPanel(props: BottomPanelProps) {
-  const { walkType, setWalkType, setIsShowReward } = props
+  const { walkType, setWalkType, setIsShowReward, distance } = props
+
   return (
     <>
       {/* 걷기 초기 상태 */}
@@ -36,7 +38,7 @@ export default function BottomPanel(props: BottomPanelProps) {
             <Image src={'/image/button/walk_stop.svg'} alt="멈추기" width="18" height="18" />
           </button>
           <span className="font-gothic-b text-[15px] text-beige ml-[62px]">
-            현재 2.3km 걷는 중&hellip;
+            현재 {distance} 걷는 중&hellip;
           </span>
         </div>
       )}
@@ -49,7 +51,9 @@ export default function BottomPanel(props: BottomPanelProps) {
           >
             <Image src={'/image/button/reward.svg'} alt="보상 받기" width="40" height="40" />
           </button>
-          <span className="font-gothic-b text-[15px] text-beige ml-[62px]">총 2.3km 걸었어요!</span>
+          <span className="font-gothic-b text-[15px] text-beige ml-[62px]">
+            총 {distance} 걸었어요!
+          </span>
         </div>
       )}
     </>

--- a/src/components/walk/Map.tsx
+++ b/src/components/walk/Map.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Loading from '@/app/loading'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { Map } from 'react-kakao-maps-sdk'
 import { Coordinates, WalkType } from '@/app/walk/page'
 
@@ -9,10 +9,89 @@ interface WalkMapProps {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
   location: Coordinates | null
   setLocation: React.Dispatch<React.SetStateAction<Coordinates | null>>
+  walkType: WalkType
+  setDistance: React.Dispatch<React.SetStateAction<number>>
 }
 
 export default function WalkMap(props: WalkMapProps) {
-  const { setIsLoading, location, setLocation } = props
+  const { setIsLoading, location, setLocation, walkType, setDistance } = props
+
+  const [map, setMap] = useState<any>(null) // Kakao Map 객체
+  const [positionArr, setPositionArr] = useState<any[]>([]) // 폴리라인 그릴 좌표 배열
+  // const [distance, setDistance] = useState<number>(0)
+
+  const [testCoordinates, setTestCoordinates] = useState([
+    { latitude: 37.5665, longitude: 126.978 }, // 시작점
+    { latitude: 37.56655, longitude: 126.97805 }, // 북동쪽 약 50m
+    { latitude: 37.5666, longitude: 126.9781 }, // 북동쪽 약 50m
+    { latitude: 37.56665, longitude: 126.97815 }, // 북동쪽 약 50m
+    { latitude: 37.5667, longitude: 126.9782 }, // 북동쪽 약 50m
+    { latitude: 37.56672, longitude: 126.9783 }, // 약간 동쪽 약 50m
+    { latitude: 37.56674, longitude: 126.9784 }, // 약간 북동쪽 약 50m
+    { latitude: 37.56676, longitude: 126.9785 }, // 약간 북쪽 약 50m
+    { latitude: 37.56678, longitude: 126.9786 }, // 약간 북쪽 약 50m
+    { latitude: 37.5668, longitude: 126.9787 }, // 북쪽 약 50m
+    { latitude: 37.56685, longitude: 126.97875 }, // 북쪽 약 50m
+    { latitude: 37.5669, longitude: 126.9788 }, // 약간 북동쪽 약 50m
+    { latitude: 37.56695, longitude: 126.97885 }, // 약간 동쪽 약 50m
+    { latitude: 37.567, longitude: 126.9789 }, // 북동쪽 약 50m
+    { latitude: 37.56705, longitude: 126.979 }, // 북동쪽 약 50m
+  ]) // 테스트용 좌표 상태로 관리
+
+  const [center, setCenter] = useState({ lat: 37.5665, lng: 126.978 }) // 지도 중심 좌표
+
+  // 폴리라인 그리는 함수
+  const makeLine = useCallback(
+    (position: any[]) => {
+      if (walkType === 'walking') {
+        const polyline = new kakao.maps.Polyline({
+          path: position,
+          strokeWeight: 3,
+          strokeColor: '#3478F5',
+          strokeOpacity: 1,
+          strokeStyle: 'solid',
+        })
+
+        // 지도에 폴리라인 표시
+        polyline.setMap(map)
+
+        // 새로운 거리 계산
+        const newDistance = polyline.getLength()
+
+        // 비동기로 상태 업데이트
+        setTimeout(() => {
+          setDistance(newDistance)
+        }, 0)
+      }
+    },
+    [map, walkType],
+  )
+
+  // 테스트용 좌표를 업데이트하는 함수
+  const addTestCoordinates = useCallback(() => {
+    if (walkType === 'walking') {
+      setTestCoordinates(prev => {
+        if (prev.length > 0) {
+          const [nextCoordinate, ...remainingCoordinates] = prev
+          const moveLatLon = new kakao.maps.LatLng(
+            nextCoordinate.latitude,
+            nextCoordinate.longitude,
+          )
+          const newPosition = positionArr.concat(moveLatLon)
+          setPositionArr(newPosition)
+
+          // 폴리라인 그리는 함수 호출
+          makeLine(newPosition)
+
+          // 지도 중심 업데이트
+          setCenter({ lat: nextCoordinate.latitude, lng: nextCoordinate.longitude })
+
+          return remainingCoordinates // 다음 상태를 갱신
+        }
+        return prev
+      })
+    }
+  }, [positionArr, makeLine, walkType])
 
   const successHandler = (response: GeolocationPosition) => {
     const { latitude, longitude } = response.coords
@@ -29,16 +108,28 @@ export default function WalkMap(props: WalkMapProps) {
     navigator.geolocation.getCurrentPosition(successHandler, errorHandler)
   }, [])
 
+  // 지도 객체 변경 시 테스트용 폴리라인 생성
+  useEffect(() => {
+    if (map && walkType === 'walking') {
+      const interval = setInterval(() => {
+        addTestCoordinates() // 테스트용 좌표 추가
+      }, 2000) // 2초마다 업데이트
+
+      return () => {
+        clearInterval(interval)
+      }
+    }
+  }, [map, addTestCoordinates, walkType])
+
   return (
     <>
       {location ? (
-        <>
-          <Map
-            center={{ lat: location.latitude, lng: location.longitude }}
-            style={{ width: '100%', height: '100vh' }}
-            level={5}
-          ></Map>
-        </>
+        <Map
+          center={center} // 지도 중심을 동적으로 설정
+          style={{ width: '100%', height: '100vh' }}
+          level={2}
+          onCreate={setMap} // Kakao Map 객체 생성 시 호출
+        ></Map>
       ) : (
         <Loading />
       )}


### PR DESCRIPTION
### 🖼️ Screen shot

https://github.com/user-attachments/assets/b59764ee-6919-4df4-91ea-4dee334af8db


### ✅ 작업 내용

- 걷기 도중 걷기 종료 시 보상 안 받고 메인 페이지로 이동
- 걷기 테스트 좌표 사용해서 이동경로 지도에 보이도록 하기

### 📝 Details

- 걷기 도중 헤더 < 버튼 클릭 시 뜨는 모달에서 '걷기 종료' 버튼 클릭 시 보상 컴포넌트를 띄우지 않고 메인페이지로 이동하도록 수정했습니다.
- 테스트 좌표를 이용해서 2초마다 경로를 지도에 보여주도록 했습니다. 추후 사용자 좌표가 변할 때 경로를 그리도록 수정할 예정입니다.

### ⚠️ 주의사항

- 현재 카테고리 작업이 더 시급하여, 사용자 좌표에 따라 이동경로 보이게 하는 건 추후 작업 예정입니다. 우선 이 pr 먼저 확인 후 머지해주시면 될 것 같습니다.
- 추후 지도 이동, 확대 등 컨트롤을 막고, 사용자 위치를 지도 정중앙에 배치하며 마커를 넣을 예정입니다.