### PR TITLE
Feature/#49: 카테고리 페이지, 올클리어 페이지 구현

### DIFF
--- a/src/app/category/[uuid]/page.tsx
+++ b/src/app/category/[uuid]/page.tsx
@@ -3,27 +3,72 @@ import Button from '@/components/common/Button'
 import CategoryField from '@/components/common/CategoryField'
 import UserProfile from '@/components/user/UserProfile'
 import Image from 'next/image'
+import type { User } from '../../hook/useFetchUserInfo'
+import { getUserInfo, getUserIsAllClear } from '@/apis/user'
+import { getAllCategoryList } from '@/apis/category'
+import { useEffect, useState } from 'react'
+import { Category, CategoryName } from '@/types/CategoryField'
+import Loading from '@/app/loading'
+import { useRouter, usePathname } from 'next/navigation'
 
 export default function AllClear() {
-  const username = '가오리영감탱구리임다'
+  const router = useRouter()
+  const pathname = usePathname()
+  const userUuid = pathname.split('/').pop() as string
 
-  return (
+  const [user, setUser] = useState<User>(null as unknown as User)
+  const [categoryList, setCategoryList] = useState<Category[]>([])
+
+  const clickHandler = () => {
+    navigator.clipboard.writeText(window.location.href).then(res => {
+      alert('주소가 복사되었습니다!')
+    })
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      const userInfo = await getUserInfo(userUuid)
+      const isUserAllClear = await getUserIsAllClear(userUuid)
+
+      if (!userInfo || !isUserAllClear) {
+        router.push('/not-found')
+      }
+
+      if (userInfo && userInfo.length > 0) {
+        setUser({
+          user_id: userInfo[0].user_id,
+          nickname: userInfo[0].nickname,
+          avatar_url: userInfo[0].avatar_url,
+        })
+      }
+      const allCategoryList = await getAllCategoryList()
+      const formattedCategoryList: Category[] = allCategoryList.map(data => ({
+        name: data.name as CategoryName,
+        status: 'completed',
+      }))
+      setCategoryList(formattedCategoryList)
+    })()
+  }, [])
+
+  return user && categoryList.length ? (
     <main className="w-full h-screen py-[70px] flex flex-col justify-center items-center">
-      <UserProfile size={100} />
+      <UserProfile size={100} imgSrc={user.avatar_url} />
       <div className="text-center mt-[30px]">
         <h1 className="text-sky-blue text-[20px] font-gothic-b mb-[4px]">
-          {username}님, 축하합니다!
+          {user.nickname}님, 축하합니다!
         </h1>
         <span className="text-brown text-[16px] font-gothic-m">
           지구가 다시 살아났어요! <br />
           지구의 결말을 바꾼 멋진 주인공이 되었네요
         </span>
       </div>
-      <CategoryField isClickable={false} />
-      <Button width={114} height={41} fontSize={16} onClick={() => alert('공유하기!')}>
+      <CategoryField isClickable={false} categoryList={categoryList} />
+      <Button width={114} height={41} fontSize={16} onClick={clickHandler}>
         <Image src="/image/share.svg" alt="" width="21" height="17" className="mr-[5px]" />
         공유하기
       </Button>
     </main>
+  ) : (
+    <Loading />
   )
 }

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -1,28 +1,61 @@
 'use client'
+
+import { useState, useEffect } from 'react'
 import Button from '@/components/common/Button'
 import CategoryField from '@/components/common/CategoryField'
+import { getAllCategoryList } from '@/apis/category'
+import { Category, CategoryName } from '@/types/CategoryField'
+import Loading from '../loading'
+import { useRouter } from 'next/navigation'
 
 export default function ChooseCategory() {
-  const focusCategory = '지구온난화'
-  return (
+  const [categoryList, setCategoryList] = useState<Category[]>([])
+  const [selectCategory, setSelectCategory] = useState<CategoryName>(
+    null as unknown as CategoryName,
+  )
+  const router = useRouter()
+
+  const clickHandler = () => {
+    localStorage.setItem('category', selectCategory)
+    router.push('/')
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      const allCategoryList = await getAllCategoryList()
+      const formattedCategoryList: Category[] = allCategoryList.map(data => ({
+        name: data.name as CategoryName,
+        status: 'default',
+      }))
+      setCategoryList(formattedCategoryList)
+    })()
+  }, [])
+
+  return categoryList.length ? (
     <main className="w-full h-screen text-center py-[57px] flex flex-col justify-center items-center">
       <div className="font-sindinaru-m">
         <h1 className="text-[15px] text-brown mb-[20px]">회복하고 싶은 캐릭터를 골라주세요</h1>
         <span className="block w-[121px] h-[40px] leading-[40px] rounded-[15px] m-auto bg-white border-none text-dark-brown">
-          {focusCategory}
+          {selectCategory}
         </span>
       </div>
-      <CategoryField />
+      <CategoryField
+        categoryList={categoryList}
+        isClickable
+        setSelectCategory={setSelectCategory}
+      />
       <Button
         width={303}
         height={40}
         fontSize={20}
         color="text-medium-brown"
         backgroundColor="bg-yellow"
-        onClick={() => alert('다음!')}
+        onClick={clickHandler}
       >
         다음
       </Button>
     </main>
+  ) : (
+    <Loading />
   )
 }

--- a/src/app/hook/useFetchUserInfo.ts
+++ b/src/app/hook/useFetchUserInfo.ts
@@ -4,7 +4,7 @@ import { getCompletedCategoryList } from '@/apis/category'
 import { getUserId, getUserInfo } from '@/apis/user'
 import { Category, CategoryName } from '@/types/CategoryField'
 
-interface User {
+export interface User {
   user_id: string
   nickname: string
   avatar_url: string

--- a/src/components/common/CategoryField.tsx
+++ b/src/components/common/CategoryField.tsx
@@ -1,26 +1,51 @@
 'use client'
 import Image from 'next/image'
 import SpotButton from './SpotButton'
-import { CategoryFieldProps } from '@/types/CategoryField'
+import { CategoryFieldProps, CategoryName } from '@/types/CategoryField'
+import { useEffect, useState } from 'react'
 
 export default function CategoryField(props: CategoryFieldProps) {
-  const { categoryList, isClickable = false, onClick } = props
+  const { categoryList, isClickable = false, onClick, setSelectCategory } = props
 
-  const buttonClickHandler = () => {
+  const [useCategoryList, setUseCategoryList] = useState(categoryList)
+
+  const buttonClickHandler = (name: CategoryName) => {
+    if (setSelectCategory) {
+      setSelectCategory(name)
+    }
+
     if (!isClickable) return
-    if (onClick) return onClick
+    setUseCategoryList(prevList => {
+      const clickedCategory = prevList.find(category => category.name === name)
+
+      if (clickedCategory?.status === 'completed') return prevList
+
+      return prevList.map(category => {
+        if (category.name === name)
+          return {
+            ...category,
+            status: category.status === 'default' ? 'selected' : 'selected',
+          }
+        else if (category.status !== 'completed') return { ...category, status: 'default' }
+        return category
+      })
+    })
   }
+
+  useEffect(() => {
+    setUseCategoryList(categoryList)
+  }, [categoryList])
 
   return (
     <div className="w-[232px] h-[232px] relative m-auto">
-      {categoryList &&
-        categoryList.map(category => (
+      {useCategoryList &&
+        useCategoryList.map(category => (
           <SpotButton
             key={category.name}
             name={category.name}
             status={category.status}
             isClickable={isClickable}
-            onClick={buttonClickHandler}
+            onClick={() => buttonClickHandler(category.name)}
           />
         ))}
       <Image src="/image/earth.svg" alt="" width="233" height="233" />

--- a/src/components/common/SpotButton.tsx
+++ b/src/components/common/SpotButton.tsx
@@ -1,6 +1,6 @@
 import { SpotButtonProps } from '@/types/CategoryField'
 import Image from 'next/image'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 const buttonInfo = {
   대기오염: {
@@ -36,34 +36,36 @@ export default function SpotButton(props: SpotButtonProps) {
 
   const clickHandler = () => {
     if (!isClickable) return
-    if (onClick) return onClick
 
-    switch (buttonStatus) {
-      case 'default':
-        setButtonStatus('selected')
-        return
-      case 'selected':
-        setButtonStatus('default')
-        return
-      case 'completed':
-        return
-    }
+    setButtonStatus(prevStatus => {
+      switch (prevStatus) {
+        case 'default':
+          return 'selected'
+        case 'selected':
+          return 'default'
+        case 'completed':
+          return prevStatus
+        default:
+          return prevStatus
+      }
+    })
   }
+
+  const imageSrc = `/image/button/${buttonInfo[name].imgName}_${buttonStatus}.svg`
+
+  useEffect(() => {
+    setButtonStatus(status)
+  }, [status])
 
   return (
     <button
       type="button"
-      onClick={clickHandler}
+      onClick={onClick || clickHandler}
       className={`absolute ${buttonInfo[name].classList} ${
         status === 'completed' || !isClickable ? 'cursor-default' : 'cursor-pointer'
       }`}
     >
-      <Image
-        src={`/image/button/${buttonInfo[name].imgName}_${status}.svg`}
-        alt={name}
-        width="46"
-        height="65"
-      />
+      <Image src={imageSrc} alt={name} width="46" height="65" />
     </button>
   )
 }

--- a/src/components/common/header/Dropdown.tsx
+++ b/src/components/common/header/Dropdown.tsx
@@ -33,7 +33,7 @@ export default function Dropdown() {
           {
             text: '공유하기',
             onClick: () => {
-              console.log('공유하기!')
+              router.push(`/category/${id}`)
             },
           },
           ...prevList,

--- a/src/types/CategoryField.ts
+++ b/src/types/CategoryField.ts
@@ -22,4 +22,5 @@ export interface CategoryFieldProps {
   categoryList: Category[]
   isClickable?: isClickable
   onClick?: () => void
+  setSelectCategory?: React.Dispatch<React.SetStateAction<CategoryName>>
 }


### PR DESCRIPTION
### 🖼️ Screen shot

| 카테고리 선택 | 올클리어 |
| :-------------: | :-------------: |
| <img width="474" alt="image" src="https://github.com/user-attachments/assets/debc9e55-56b4-4d73-849a-424f9e62104a"> | <img width="480" alt="image" src="https://github.com/user-attachments/assets/b31012e2-43b7-475f-a0ff-b98725ec7a6e"> |


### ✅ 작업 내용

- 카테고리 페이지, 올클리어 페이지 구현
- Dropdown > 공유하기 버튼 클릭 시 유저 uuid를 url에 포함해 이동하도록 구현

### 📝 Details

- 카테고리 선택 시 로컬스토리지 `category` 키에 `카테고리명`을 값으로 저장합니다.
- 올클리어한 유저일 시 마이홈 헤더의 Dropdown에 공유하기 버튼이 생기는데 이를 클릭 시 로그인한 유저의 uuid를 url에 담아 올클리어 페이지로 이동합니다.
- 올클리어 페이지에서 url에 있는 uuid가 정상인지 확인, 해당 유저가 올클리어한 유저가 맞는지 판단 후 맞다면 올클리어 화면을 그리고, 만약 아니라면 /not-found 페이지로 이동해 잘못된 페이지임을 알립니다.
- 올클리어 페이지에서 공유하기 버튼 클릭 시 해당 url을 클립보드에 복사합니다.

### ⚠️ 주의사항

- 카테고리 선택 페이지에서 이미 클리어한 카테고리를 completed 하거나, 아직 스테이지를 진행 중일 때 category 페이지에 접근하지 못하도록 하는 추가 작업을 해야 합니다.
