### PR TITLE
(feature/#66): 남은 카테고리 페이지 기능 구현

### DIFF
--- a/src/apis/category.ts
+++ b/src/apis/category.ts
@@ -84,3 +84,51 @@ export const updateProgress = async (user_id: string, points: number) => {
     .update({ progress: currentPoints + points })
     .eq('user_id', user_id)
 }
+
+/**
+ * 카테고리 이름으로 ID 반환
+ * @param name 카테고리 이름
+ * @returns 해당 카테고리 ID
+ */
+export const getCategoryIdByName = async (name: string) => {
+  const { data, error } = await supabase.from('category').select('id').eq('name', name)
+
+  if (error) return console.error('카테고리 ID 조회 실패:', error.message)
+  return data[0].id
+}
+/**
+ * 새로운 카테고리 진행 데이터 생성
+ * @param userId 유저 UUID
+ * @param name 카테고리 이름
+ */
+export const createCategoryProgress = async (user_id: string, name: string) => {
+  const category_id = await getCategoryIdByName(name)
+  if (!category_id) return
+
+  const { error } = await supabase.from('category_progress').insert({
+    user_id,
+    category_id,
+    progress: 0,
+    is_completed: false,
+  })
+
+  if (error) return console.error('카테고리 진행 생성 실패:', error.message)
+  console.log('카테고리 진행 생성 성공')
+}
+
+/**
+ * 특정 유저의 `category_progress` 테이블에서 모든 카테고리 진행 상태(`is_completed`) 조회
+ * @param {string} user_id - 진행 상태를 조회할 유저의 UUID.
+ * @returns {Promise<Array<{ is_completed: boolean }> | null>}
+ * 각 카테고리 진행 상태(`is_completed`)를 포함한 객체 배열 반환
+ */
+export const getCategoryProgressIsCompleted = async (user_id: string) => {
+  const supabase = createSupabaseBrowserClient()
+  const { data, error } = await supabase
+    .from('category_progress')
+    .select('is_completed')
+    .eq('user_id', user_id)
+  console.log('data', data)
+  if (error) console.error('error: ', error.message)
+  return data
+}

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -1,37 +1,55 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useUpdatedCategoryList } from '../hook/useUpdatedCategoryList'
+import { useEffect, useState, useCallback } from 'react'
+import { CategoryName } from '@/types/CategoryField'
+import { useRouter } from 'next/navigation'
+import Loading from '../loading'
 import Button from '@/components/common/Button'
 import CategoryField from '@/components/common/CategoryField'
-import { getAllCategoryList } from '@/apis/category'
-import { Category, CategoryName } from '@/types/CategoryField'
-import Loading from '../loading'
-import { useRouter } from 'next/navigation'
+import { createCategoryProgress, getCategoryProgressIsCompleted } from '@/apis/category'
+import { getUserId } from '@/apis/user'
 
 export default function ChooseCategory() {
-  const [categoryList, setCategoryList] = useState<Category[]>([])
+  const { categoryListWithStatus, isLoading } = useUpdatedCategoryList()
   const [selectCategory, setSelectCategory] = useState<CategoryName>(
     null as unknown as CategoryName,
   )
   const router = useRouter()
 
-  const clickHandler = () => {
-    localStorage.setItem('category', selectCategory)
-    router.push('/')
-  }
+  // TODO: 주석 제거 예정
+  // // 접근 권한을 확인하고, 조건에 따라 리다이렉션
+  // const checkAccess = useCallback(async () => {
+  //   try {
+  //     const userId = (await getUserId()) as string
+  //     const data = await getCategoryProgressIsCompleted(userId)
+  //     const hasIncompleteProgress = data.some(item => !item.is_completed)
+  //     if (hasIncompleteProgress) router.push('/')
+  //   } catch (error) {
+  //     console.error('Failed to check access:', error)
+  //   }
+  // }, [router])
 
-  useEffect(() => {
-    ;(async () => {
-      const allCategoryList = await getAllCategoryList()
-      const formattedCategoryList: Category[] = allCategoryList.map(data => ({
-        name: data.name as CategoryName,
-        status: 'default',
-      }))
-      setCategoryList(formattedCategoryList)
-    })()
-  }, [])
+  // // 컴포넌트 마운트 시 접근 권한 확인
+  // useEffect(() => {
+  //   checkAccess()
+  // }, [checkAccess])
 
-  return categoryList.length ? (
+  // 선택된 카테고리로 진행을 생성하고 홈으로 리다이렉션
+  const clickHandler = useCallback(async () => {
+    try {
+      localStorage.setItem('category', selectCategory)
+      const userId = (await getUserId()) as string
+      await createCategoryProgress(userId, selectCategory)
+      router.push('/')
+    } catch (error) {
+      console.error('Failed to create category progress:', error)
+    }
+  }, [selectCategory, router])
+
+  if (isLoading) return <Loading />
+
+  return (
     <main className="w-full h-screen text-center py-[57px] flex flex-col justify-center items-center">
       <div className="font-sindinaru-m">
         <h1 className="text-[15px] text-brown mb-[20px]">회복하고 싶은 캐릭터를 골라주세요</h1>
@@ -40,22 +58,24 @@ export default function ChooseCategory() {
         </span>
       </div>
       <CategoryField
-        categoryList={categoryList}
+        categoryList={categoryListWithStatus}
         isClickable
         setSelectCategory={setSelectCategory}
       />
-      <Button
-        width={303}
-        height={40}
-        fontSize={20}
-        color="text-medium-brown"
-        backgroundColor="bg-yellow"
-        onClick={clickHandler}
-      >
-        다음
-      </Button>
+      <div className="h-[40px] flex items-center justify-center">
+        {selectCategory && (
+          <Button
+            width={303}
+            height={40}
+            fontSize={20}
+            color="text-medium-brown"
+            backgroundColor="bg-yellow"
+            onClick={clickHandler}
+          >
+            다음
+          </Button>
+        )}
+      </div>
     </main>
-  ) : (
-    <Loading />
   )
 }

--- a/src/app/hook/useUpdatedCategoryList.ts
+++ b/src/app/hook/useUpdatedCategoryList.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { useFetchUserInfo } from './useFetchUserInfo'
+import { getAllCategoryList } from '@/apis/category'
+import { Category } from '@/types/CategoryField'
+
+export const useUpdatedCategoryList = () => {
+  const { categoryList: completedCategoryList } = useFetchUserInfo()
+  const [categoryListWithStatus, setCategoryListWithStatus] = useState<Category[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    const fetchCategoryList = async () => {
+      try {
+        setIsLoading(true)
+        const allCategoryList = await getAllCategoryList()
+        const updatedCategoryList = allCategoryList.map(data => {
+          const isCompleted = completedCategoryList.some(completed => completed.name === data.name)
+          return {
+            name: data.name,
+            status: isCompleted ? 'completed' : 'default',
+          }
+        })
+        setCategoryListWithStatus(updatedCategoryList)
+      } catch (err) {
+        setError(err as Error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchCategoryList()
+  }, [completedCategoryList])
+
+  return { categoryListWithStatus, isLoading, error }
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -16,7 +16,7 @@ export default function MyPage() {
         </span>
       </div>
       <div className="w-full h-screen flex justify-center">
-        <CategoryField categoryList={categoryList} />
+        <CategoryField categoryList={categoryList} isClickable />
       </div>
     </main>
   )

--- a/src/components/common/SpotButton.tsx
+++ b/src/components/common/SpotButton.tsx
@@ -1,6 +1,6 @@
 import { SpotButtonProps } from '@/types/CategoryField'
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 
 const buttonInfo = {
   대기오염: {
@@ -31,41 +31,31 @@ const buttonInfo = {
 
 export default function SpotButton(props: SpotButtonProps) {
   const { name, status = 'default', onClick, isClickable = false } = props
-
   const [buttonStatus, setButtonStatus] = useState(status)
 
-  const clickHandler = () => {
+  // 클릭 가능 여부 확인 후 버튼 상태 변경
+  const handleButtonClick = useCallback(() => {
     if (!isClickable) return
 
     setButtonStatus(prevStatus => {
-      switch (prevStatus) {
-        case 'default':
-          return 'selected'
-        case 'selected':
-          return 'default'
-        case 'completed':
-          return prevStatus
-        default:
-          return prevStatus
-      }
+      if (prevStatus === 'default') return 'selected'
+      if (prevStatus === 'selected') return 'default'
+      return prevStatus
     })
-  }
-
-  const imageSrc = `/image/button/${buttonInfo[name].imgName}_${buttonStatus}.svg`
+  }, [isClickable])
 
   useEffect(() => {
     setButtonStatus(status)
   }, [status])
 
+  const imageSrc = `/image/button/${buttonInfo[name]?.imgName}_${buttonStatus}.svg`
+  const buttonClass = `absolute ${buttonInfo[name]?.classList} ${
+    isClickable ? 'cursor-pointer' : 'cursor-default'
+  }`
+
   return (
-    <button
-      type="button"
-      onClick={onClick || clickHandler}
-      className={`absolute ${buttonInfo[name].classList} ${
-        status === 'completed' || !isClickable ? 'cursor-default' : 'cursor-pointer'
-      }`}
-    >
-      <Image src={imageSrc} alt={name} width="46" height="65" />
+    <button type="button" onClick={onClick || handleButtonClick} className={buttonClass}>
+      <Image src={imageSrc} alt={name} width={46} height={65} />
     </button>
   )
 }


### PR DESCRIPTION
### 🖼️ Screen shot

https://github.com/user-attachments/assets/78eb3a7a-b71e-4f48-9f6d-268b99e01cc7


https://github.com/user-attachments/assets/8fe6f840-1d0f-4e20-9e1a-a443bd68078a




### ✅ 작업 내용

- 카테고리 페이지(`/category`)
  - 클리어한 카테고리는 클릭 불가능
  - 유저의 카테고리가 클리어되지 않았다면, 카테고리 페이지 방문 불가
    (`TODO: 주석 제거 예정`으로 주석으로 만들어놨습니다.)
  - '다음' 버튼 클릭 시 `category_progress` 테이블에 데이터 추가
- 마이홈 페이지(`/mypage`)
  - 클리어한 카테고리 클릭 시 `alert()`


### ⚠️ 주의사항

- 클리어한 카테고리 페이지가 아직 구현되지 않아 `alert()`으로만 해뒀습니다.


### 💬 Thinking

- 올클리어 페이지(`/category/[uuid]`)에서 `uuid`를 사용하기 때문에 사용자가 접근할 수 없을 것 같아 따로 접근을 막는 기능은 만들지 않았습니다. 혹시 이 부분을 구현해야 할까요?
- 마이홈 페이지에서 카테고리를 클릭하면 해당 카테고리가 회복된 페이지로 가야하는데 주소를 어떻게 해야할지 모르겠습니당... 
  - 카테고리에 대한 내용이기 때문에 `category`를 사용해야 할 것 같은데, 마이홈에서 이동할 수 있어서 `mypage`를 사용해야 할 것 같기도 합니다.
