### PR TITLE
(feature/#71): 남은 카테고리 기능 처리

### DIFF
--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -7,7 +7,11 @@ import { useRouter } from 'next/navigation'
 import Loading from '../loading'
 import Button from '@/components/common/Button'
 import CategoryField from '@/components/common/CategoryField'
-import { createCategoryProgress, getCategoryProgressIsCompleted } from '@/apis/category'
+import {
+  createCategoryProgress,
+  getCategoryIdByName,
+  getCategoryProgressIsCompleted,
+} from '@/apis/category'
 import { getUserId } from '@/apis/user'
 
 export default function ChooseCategory() {
@@ -23,7 +27,7 @@ export default function ChooseCategory() {
   //   try {
   //     const userId = (await getUserId()) as string
   //     const data = await getCategoryProgressIsCompleted(userId)
-  //     const hasIncompleteProgress = data.some(item => !item.is_completed)
+  //     const hasIncompleteProgress = data?.some(item => !item.is_completed)
   //     if (hasIncompleteProgress) router.push('/')
   //   } catch (error) {
   //     console.error('Failed to check access:', error)
@@ -38,7 +42,13 @@ export default function ChooseCategory() {
   // 선택된 카테고리로 진행을 생성하고 홈으로 리다이렉션
   const clickHandler = useCallback(async () => {
     try {
-      localStorage.setItem('category', selectCategory)
+      localStorage.setItem(
+        'category',
+        JSON.stringify({
+          id: await getCategoryIdByName(selectCategory),
+          name: selectCategory,
+        }),
+      )
       const userId = (await getUserId()) as string
       await createCategoryProgress(userId, selectCategory)
       router.push('/')


### PR DESCRIPTION
### ✅ 작업 내용

- 카테고리 선택 페이지(/category)
  - 로컬 스토리지에 카테고리 이름 -> 카테고리 아이디, 이름 모두 저장
- 마이홈 페이지(/mypage)
  - 로컬 스토리지에 `viewResultCategory`로 결과로 보고싶은 카테고리 아이디, 이름 저장

### 📝 Details

- 로컬스토리지에 저장되는 형태: `{ id: 4, name: '지구온난화' }`

### ⚠️ 주의사항

- 메인 페이지에서 `viewResultCategory`가 존재하면 보여주고 '돌아가기' 버튼을 누르면 `viewResultCategory`를 로컬스토리지에서 삭제해주세요.