### PR TITLE
Feature/#70: Zustand 이용해서 category_id, user_id store에 저장

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,10 @@
+FROM node:20.12.2
+
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run","dev"]

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: Request) {
         email: user.email!,
         avatar_url: user.user_metadata?.avatar_url,
       })
-      return NextResponse.redirect(`${overrideOrigin}/category`)
+      return NextResponse.redirect(`${overrideOrigin}/category?user_id=${user.id}`)
     }
   } catch (err) {
     console.error('Failed to handle user data:', err)

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -7,6 +7,7 @@ import { getAllCategoryList } from '@/apis/category'
 import { Category, CategoryName } from '@/types/CategoryField'
 import Loading from '../loading'
 import { useRouter } from 'next/navigation'
+import useUserStore from '@/store/useUserStore'
 
 export default function ChooseCategory() {
   const [categoryList, setCategoryList] = useState<Category[]>([])
@@ -14,22 +15,50 @@ export default function ChooseCategory() {
     null as unknown as CategoryName,
   )
   const router = useRouter()
+  // Zustand 상태 업데이트 함수 가져오기
+  const { setUserId, setCategoryId } = useUserStore()
 
   const clickHandler = () => {
-    localStorage.setItem('category', selectCategory)
+    // categoryList에서 선택된 카테고리를 찾습니다.
+    const selectedCategory = categoryList.find(category => category.name === selectCategory)
+
+    if (selectedCategory) {
+      // 선택된 카테고리의 id를 Zustand에 저장
+      setCategoryId(selectedCategory.id) // categoryId 저장
+      console.log('Stored categoryId in Zustand:', selectedCategory.id)
+    } else {
+      console.warn('No category found for the selected name:', selectCategory)
+    }
+
+    // category name을 localStorage에 저장
+    localStorage.setItem('category', selectCategory) // 선택한 카테고리 이름 저장
+
+    // 페이지 이동
     router.push('/')
   }
 
+  // user_id 저장 및 카테고리 리스트 가져오기
   useEffect(() => {
+    // URL에서 user_id를 가져와 상태에 저장
+    const query = new URLSearchParams(window.location.search)
+    const userId = query.get('user_id')
+    if (userId) {
+      setUserId(userId) // Zustand에 user_id 저장
+      console.log('Zustand store에 userId 저장:', userId)
+    } else {
+      console.log('No user_id found in URL.')
+    }
+
     ;(async () => {
       const allCategoryList = await getAllCategoryList()
-      const formattedCategoryList: Category[] = allCategoryList.map(data => ({
+      const formattedCategoryList: Category[] = allCategoryList.map((data, index) => ({
+        id: data.id || index, // categoryId가 없으면 index 사용
         name: data.name as CategoryName,
         status: 'default',
       }))
       setCategoryList(formattedCategoryList)
     })()
-  }, [])
+  }, [setUserId])
 
   return categoryList.length ? (
     <main className="w-full h-screen text-center py-[57px] flex flex-col justify-center items-center">

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -7,23 +7,22 @@ import Answer from '@/components/quiz/Answer'
 import Message from '@/components/quiz/Message'
 
 import { QuizDto } from '@/types/Quiz'
-
 import { getUnsolvedQuizzes } from '@/apis/quiz'
-import { getUserId } from '@/apis/user'
+import useUserStore from '@/store/useUserStore'
 
 export default function Page() {
   const [quizList, setQuizList] = useState<QuizDto[]>([])
   const [currentQuizIndex, setCurrentQuizIndex] = useState(0)
   const [isLoading, setIsLoading] = useState(true) // 로딩 상태 추가
 
-  const categoryId = 1 // 테스트용 카테고리 ID
+  const { userId, categoryId } = useUserStore()
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         setIsLoading(true)
-        const userId = await getUserId()
-        if (!userId) throw new Error('User ID not found')
+        if (!userId) throw new Error('User ID가 없습니다.')
+        if (!categoryId) throw new Error('Category ID가 없습니다.') // null 처리
 
         const data = await getUnsolvedQuizzes(userId, categoryId)
         if (data.length > 0) {
@@ -38,7 +37,7 @@ export default function Page() {
     }
 
     fetchData()
-  }, [])
+  }, [userId, categoryId])
 
   const currentQuiz = quizList[currentQuizIndex]
 

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -9,31 +9,28 @@ import Calendar from '@/components/report/calendar/Calendar'
 import TodayEcoStats from '@/components/report/TodayEcoStats'
 import WeeklyEcoChart from '@/components/report/WeeklyEcoChart'
 
-import { getDateInfo, updateGoal } from '@/apis/date'
 import { DateInfo } from '@/types/Date'
-
-import { getUserId, getUserInfo } from '@/apis/user'
+import { getDateInfo, updateGoal } from '@/apis/date'
+import { getUserInfo } from '@/apis/user'
+import useUserStore from '@/store/useUserStore'
 
 export default function page() {
   const [dateInfo, setDateInfo] = useState<DateInfo[]>([])
   const [selectedDate, setSelectedDate] = useState<DateInfo | null>(null)
   const [weekRange, setWeekRange] = useState<{ start: string; end: string } | null>(null)
   const [filteredWeeklyData, setFilteredWeeklyData] = useState<DateInfo[]>([])
-  const [userId, setUserId] = useState<string>('')
   const [goalKm, setGoalKm] = useState(3)
+  const { userId } = useUserStore()
+
+  console.log(userId)
 
   useEffect(() => {
     const fetchDateInfo = async () => {
       try {
-        // 임시 테스트용 -> 변경 예정
-        const id = await getUserId()
-        if (!id) throw new Error('User ID not found')
-        setUserId(id)
+        if (!userId) throw new Error('User ID가 없습니다.')
 
         const userGoal = await getUserInfo(userId)
         setGoalKm(userGoal?.[0].goal || 3)
-
-        // console.log('gg', userGoal?.[0].goal)
 
         const data = await getDateInfo(userId)
         if (data.length > 0) {
@@ -66,6 +63,8 @@ export default function page() {
   const updateGoalKm = async (newGoal: number) => {
     try {
       setGoalKm(newGoal)
+      if (!userId) throw new Error('User ID가 없습니다.')
+
       await updateGoal(userId, newGoal) // DB 업데이트
     } catch (error) {
       console.error('Failed to update goal:', error)
@@ -83,6 +82,8 @@ export default function page() {
     if (record) {
       setSelectedDate(record)
     } else {
+      if (!userId) throw new Error('User ID가 없습니다.')
+
       setSelectedDate({
         id: 0,
         created_at: formattedDate,

--- a/src/components/quiz/Answer.tsx
+++ b/src/components/quiz/Answer.tsx
@@ -11,7 +11,7 @@ import useModal from '@/app/hook/useModal'
 import { QuizDto } from '@/types/Quiz'
 import { updateUserPoint, insertQuizLog } from '@/apis/quiz'
 import { updateProgress } from '@/apis/category'
-import { getUserId } from '@/apis/user'
+import useUserStore from '@/store/useUserStore'
 
 interface AnswerProps {
   currentQuiz: QuizDto
@@ -24,6 +24,7 @@ export default function Answer(props: AnswerProps) {
   const [isShowReward, setIsShowReward] = useState(false)
   const [rewardContent, setRewardContent] = useState<React.ReactNode>(null)
   const [yaho, setYaho] = useState<string>()
+  const { userId } = useUserStore()
 
   const handleCloseReward = () => {
     setIsShowReward(false)
@@ -37,7 +38,6 @@ export default function Answer(props: AnswerProps) {
 
   const handleAnswerClick = async (value: boolean) => {
     // 임시 테스트용 -> 변경 예정
-    const userId = await getUserId()
     if (!userId) throw new Error('User ID not found')
 
     const isCorrect = value === currentQuiz.is_answer

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand'
+
+interface UserState {
+  userId: string | null
+  categoryId: number | null
+  setUserId: (id: string) => void
+  setCategoryId: (id: number) => void
+  clearUser: () => void
+}
+
+const useUserStore = create<UserState>(set => ({
+  userId: null,
+  categoryId: null,
+  setUserId: id => set({ userId: id }),
+  setCategoryId: id => set({ categoryId: id }),
+  clearUser: () => set({ userId: null, categoryId: null }),
+}))
+
+export default useUserStore

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 interface UserState {
   userId: string | null
@@ -8,12 +9,33 @@ interface UserState {
   clearUser: () => void
 }
 
-const useUserStore = create<UserState>(set => ({
-  userId: null,
-  categoryId: null,
-  setUserId: id => set({ userId: id }),
-  setCategoryId: id => set({ categoryId: id }),
-  clearUser: () => set({ userId: null, categoryId: null }),
-}))
+const zustandLocalStorage = {
+  getItem: (name: string) => {
+    const value = localStorage.getItem(name)
+    return value ? JSON.parse(value) : null
+  },
+  setItem: (name: string, value: any) => {
+    localStorage.setItem(name, JSON.stringify(value))
+  },
+  removeItem: (name: string) => {
+    localStorage.removeItem(name)
+  },
+}
+
+const useUserStore = create(
+  persist<UserState>(
+    set => ({
+      userId: null,
+      categoryId: null,
+      setUserId: id => set({ userId: id }),
+      setCategoryId: id => set({ categoryId: id }),
+      clearUser: () => set({ userId: null, categoryId: null }),
+    }),
+    {
+      name: 'user-store', // 로컬 스토리지 키
+      storage: zustandLocalStorage, // Custom storage wrapper
+    },
+  ),
+)
 
 export default useUserStore

--- a/src/types/CategoryField.ts
+++ b/src/types/CategoryField.ts
@@ -9,6 +9,7 @@ type CategoryStatus = 'default' | 'selected' | 'completed'
 type isClickable = boolean
 
 export interface Category {
+  id: number
   name: CategoryName
   status?: CategoryStatus
 }


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
| <img width="638" alt="스크린샷 2024-11-28 오전 4 00 49" src="https://github.com/user-attachments/assets/db263104-d993-4679-9219-4cba9a6921cb">   |

### ✅ 작업 내용

- zustand `store` 생성 후 local에 `user-store`로 저장

### 📝 Details

- 리다이렉트 시, user_id를 URL의 쿼리 파라미터로 포함 `(/category?user_id=${user.id}`
- `zustand/middleware`의 `persist`를 사용하여 `userId`와 `categoryId`를 로컬 스토리지에 저장
- Category의 type에 `id` 추가
- Zustand를 통해 전역 상태로 관리 중인 `userId`와 `categoryId`를 컴포넌트에서 활용

### 💻 예시코드

```jsx
// 활용 예시
const { userId, categoryId } = useUserStore()

// null 처리 예시
if (!userId) throw new Error('User ID가 없습니다.')
if (!categoryId) throw new Error('Category ID가 없습니다.') // null 처리

```

### ⚠️ 주의사항

- zustand에서 가져와서 사용할 때 null 처리 해줘야 합니다.
- 현재 category_id가 localstorage에서도 저장은 되고 있습니다. 추후에 zustand 문제 없으면 지울 예정

### 💬 Thinking

- 추후에 zustand에서 문제가 없으면 goal, category_name도 추가 저장하는 방식 고려해봐도 좋을거 같아요.
