### PR TITLE
Feature/#43 뱃지화면 추가, 재로그인 화면 변경

### DIFF
--- a/src/apis/main.ts
+++ b/src/apis/main.ts
@@ -21,11 +21,17 @@ export const getProgress = async (user_id: string, category_id: number) => {
 export const upgradeProgress = async (user_id: string, category_id: number) => {
   try {
     const currentProgress = await getProgress(user_id, category_id)
-    await supabase
+    const validProgress = currentProgress ?? 0
+
+    const { error: updateError } = await supabase
       .from('category_progress')
-      .update({ progress: currentProgress! + 10 }) //오류가능성
+      .update({ progress: validProgress + 10 })
       .eq('user_id', user_id)
       .eq('category_id', category_id)
+
+    if (updateError) {
+      throw new Error(`Failed to update progress: ${updateError.message}`)
+    }
   } catch (error) {
     console.error('Error in decreaseUserPoint:', error)
   }
@@ -69,5 +75,84 @@ export const usePotion = async (user_id: string) => {
     }
   } catch (error) {
     console.error('Error in decreaseUserPoint:', error)
+  }
+}
+
+// export const getCompletedCategoryCount = async (user_id: string) => {
+//   try {
+//     const { count, error } = await supabase
+//       .from('category_progress')
+//       .select('*', { count: 'exact', head: true })
+//       .eq('user_id', user_id)
+//       .eq('is_completed', true)
+
+//     if (error) {
+//       console.error('is_completed 데이터 개수 가져오기 실패:', error)
+//       return null
+//     }
+
+//     return count || 0 // count가 null이면 0 반환
+//   } catch (error) {
+//     console.error('getCompletedCategoryCount 오류:', error)
+//     return null
+//   }
+// }
+
+export const updateIsAllCompleted = async (user_id: string) => {
+  try {
+    // category_progress 테이블에서 user_id에 해당하는 레코드 확인
+    const { data, error: progressError } = await supabase
+      .from('category_progress')
+      .select('is_completed')
+      .eq('user_id', user_id)
+
+    if (progressError) {
+      throw new Error(`Failed to fetch category_progress: ${progressError.message}`)
+    }
+
+    if (!data || data.length === 0) {
+      throw new Error(`No category_progress records found for user_id: ${user_id}`)
+    }
+
+    // 레코드 개수 확인
+    const hasSixRecords = data.length === 6
+    // 모든 레코드의 is_completed가 true인지 확인
+    const allCompleted = data.every(item => item.is_completed === true)
+
+    // user 테이블의 isAllCompleted 값 업데이트
+    if (hasSixRecords && allCompleted) {
+      const { error: userError } = await supabase
+        .from('user')
+        .update({ is_all_clear: true })
+        .eq('user_id', user_id)
+
+      if (userError) {
+        throw new Error(`Failed to update user table: ${userError.message}`)
+      }
+
+      console.log(`User ${user_id} isAllCompleted updated to: ${allCompleted}`)
+    }
+  } catch (error) {
+    console.error('Error in updateIsAllCompleted:', error)
+  }
+}
+
+export const getIsAllCompleted = async (user_id: string): Promise<boolean | null> => {
+  try {
+    const { data, error } = await supabase
+      .from('user')
+      .select('is_all_clear')
+      .eq('user_id', user_id)
+      .single()
+
+    if (error) {
+      console.error('Error fetching is_all_clear:', error)
+      return null
+    }
+
+    return data?.is_all_clear ?? null // 값이 없으면 null 반환
+  } catch (error) {
+    console.error('Unexpected error in getIsAllCompleted:', error)
+    return null
   }
 }

--- a/src/apis/main.ts
+++ b/src/apis/main.ts
@@ -78,26 +78,6 @@ export const usePotion = async (user_id: string) => {
   }
 }
 
-// export const getCompletedCategoryCount = async (user_id: string) => {
-//   try {
-//     const { count, error } = await supabase
-//       .from('category_progress')
-//       .select('*', { count: 'exact', head: true })
-//       .eq('user_id', user_id)
-//       .eq('is_completed', true)
-
-//     if (error) {
-//       console.error('is_completed 데이터 개수 가져오기 실패:', error)
-//       return null
-//     }
-
-//     return count || 0 // count가 null이면 0 반환
-//   } catch (error) {
-//     console.error('getCompletedCategoryCount 오류:', error)
-//     return null
-//   }
-// }
-
 export const updateIsAllCompleted = async (user_id: string) => {
   try {
     // category_progress 테이블에서 user_id에 해당하는 레코드 확인

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -79,7 +79,10 @@ export default function Page() {
         // 카테고리 완료하면 다음 생성 DB로
         const getCategory = await getCategoryProgress(userId)
         const incompleteCategory = getCategory.find(category => !category.is_completed)
-        if (!incompleteCategory) throw new Error('No incomplete category found')
+        if (!incompleteCategory) {
+          setIsAllCompleted(true)
+          return
+        }
 
         // 조건에 맞는 카테고리 ID로 설정
         const categoryId = incompleteCategory.category_id
@@ -230,6 +233,23 @@ export default function Page() {
           level={level}
           isAllCompleted={isAllCompleted}
         />
+      )}
+
+      {isAllCompleted && (
+        <div className="absolute bg-cream w-full h-full justify-center items-center flex flex-col space-y-6">
+          <p className="font-gothic-b text-brown">주민을 모두 구했습니다!</p>
+          <Button
+            width={104}
+            height={40}
+            fontSize={16}
+            backgroundColor="bg-mint"
+            color="text-light-mint"
+            isLink
+            href="/mypage"
+            children="마이홈으로"
+            isMediumFont
+          />
+        </div>
       )}
     </div>
   )

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -7,7 +7,13 @@ import FooterButtons from '@/components/main/FooterButtons'
 import Levelup from '@/components/main/Levelup'
 import ProgressBar from '@/components/common/ProgressBar'
 import Button from '@/components/common/Button'
-import { getPotion, getProgress, upgradeProgress, usePotion } from '@/apis/main'
+import {
+  getPotion,
+  getProgress,
+  updateIsAllCompleted,
+  upgradeProgress,
+  usePotion,
+} from '@/apis/main'
 import { getUserId } from '@/apis/user'
 import { changeComplete, getCategoryProgress } from '@/apis/category'
 import dynamic from 'next/dynamic'
@@ -20,11 +26,12 @@ export default function Page() {
   const [categoryId, setCategoryId] = useState<number>(1)
   const [loading, setLoading] = useState(true) // 로딩 상태 추가
 
-  // 임의 물약 & 경험치
+  // 물약 & 경험치
   const [potion, setPotion] = useState<number | null>(null)
   const [currentProgress, setCurrentProgress] = useState<number | null>(null)
   const [level, setLevel] = useState(1)
   const [isEnd, setIsEnd] = useState(false)
+  const [isAllCompleted, setIsAllCompleted] = useState(false)
 
   const getSelectedCharacter = (
     categoryId: number,
@@ -54,29 +61,35 @@ export default function Page() {
   const [message, setMessage] = useState('')
   const [isShowLevelup, setIsShowLevelup] = useState(false)
 
+  useEffect(() => {
+    if (isAllCompleted) {
+      console.log('All categories completed!')
+    }
+  }, [isAllCompleted])
+
   // 페이지가 로드될 때 유저의 potion 값 불러오기
   useEffect(() => {
     const fetchPotionAndProgress = async () => {
       try {
+        // 유저 ID
         const userId = await getUserId()
         if (!userId) throw new Error('User ID not found')
         setUserId(userId)
 
+        // 카테고리 완료하면 다음 생성 DB로
         const getCategory = await getCategoryProgress(userId)
         const incompleteCategory = getCategory.find(category => !category.is_completed)
-
-        // 만약 불완전한 카테고리를 찾지 못했다면 에러 처리
         if (!incompleteCategory) throw new Error('No incomplete category found')
 
         // 조건에 맞는 카테고리 ID로 설정
         const categoryId = incompleteCategory.category_id
         setCategoryId(categoryId)
 
+        // 포션, 진행도 불러오기
         const initialPoint = await getPotion(userId)
         const initialProgress = await getProgress(userId, categoryId)
 
         if (initialPoint !== null) setPotion(initialPoint)
-
         if (initialProgress !== null) {
           setCurrentProgress(initialProgress)
 
@@ -140,7 +153,15 @@ export default function Page() {
         setCurrentProgress(0)
       } else if (level === 3 && newProgress === 200) {
         setIsShowLevelup(true)
-        changeComplete(userId, categoryId!)
+        changeComplete(userId, categoryId)
+        const getCategory = await getCategoryProgress(userId) // 업데이트된 카테고리 진행 상태 확인
+        const allCompleted = getCategory.every(category => category.is_completed)
+
+        if (allCompleted && getCategory.length === 6) {
+          // 모든 카테고리가 완료되었고 데이터베이스 개수가 6개일 때
+          await updateIsAllCompleted(userId)
+          setIsAllCompleted(true) // 상태 업데이트
+        }
       }
     }
   }
@@ -207,6 +228,7 @@ export default function Page() {
           index={index}
           onClose={handleCloseLevelup}
           level={level}
+          isAllCompleted={isAllCompleted}
         />
       )}
     </div>

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -30,18 +30,10 @@ export async function GET(request: Request) {
     // user 테이블에서 유저 정보 확인
     const { data: existingUser, error: checkError } = await supabase
       .from('user')
-      .select('*')
+      .select('is_all_clear, user_id, email')
       .eq('user_id', user.id)
       .maybeSingle()
     if (checkError) throw checkError
-
-    const { data: completeUser, error } = await supabase
-      .from('user')
-      .select('is_all_clear')
-      .eq('user_id', user.id)
-      .eq('is_all_clear', true)
-      .single()
-    if (error) throw new Error()
 
     if (!existingUser) {
       // 유저 정보가 없는 경우 새로 생성하고 카테고리 페이지로 이동
@@ -52,7 +44,8 @@ export async function GET(request: Request) {
       })
       return NextResponse.redirect(`${overrideOrigin}/category?user_id=${user.id}`)
     }
-    if (completeUser) {
+
+    if (existingUser.is_all_clear) {
       return NextResponse.redirect(`${overrideOrigin}/category/${user.id}`)
     }
   } catch (err) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
     // user 테이블에서 유저 정보 확인
     const { data: existingUser, error: checkError } = await supabase
       .from('user')
-      .select('is_all_clear, user_id, email')
+      .select('*')
       .eq('user_id', user.id)
       .maybeSingle()
     if (checkError) throw checkError

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -33,17 +33,27 @@ export async function GET(request: Request) {
       .select('*')
       .eq('user_id', user.id)
       .maybeSingle()
-
     if (checkError) throw checkError
 
-    // 유저 정보가 없는 경우 새로 생성하고 카테고리 페이지로 이동
+    const { data: completeUser, error } = await supabase
+      .from('user')
+      .select('is_all_clear')
+      .eq('user_id', user.id)
+      .eq('is_all_clear', true)
+      .single()
+    if (error) throw new Error()
+
     if (!existingUser) {
+      // 유저 정보가 없는 경우 새로 생성하고 카테고리 페이지로 이동
       await createUser({
         id: user.id,
         email: user.email!,
         avatar_url: user.user_metadata?.avatar_url,
       })
       return NextResponse.redirect(`${overrideOrigin}/category?user_id=${user.id}`)
+    }
+    if (completeUser) {
+      return NextResponse.redirect(`${overrideOrigin}/category/${user.id}`)
     }
   } catch (err) {
     console.error('Failed to handle user data:', err)

--- a/src/app/badge/page.tsx
+++ b/src/app/badge/page.tsx
@@ -1,3 +1,4 @@
+'use client'
 import characterGroup from '@/assets/characterData'
 import Button from '@/components/common/Button'
 import ProgressBar from '@/components/common/ProgressBar'
@@ -5,8 +6,44 @@ import CharacterSection from '@/components/main/CharacterSection'
 import Image from 'next/image'
 import React from 'react'
 
-const badge = () => {
-  const selectedCharacter = 'soil'
+function getStoredCategoryId() {
+  // localStorage에서 데이터 가져오기
+  const storedData = localStorage.getItem('viewResultCategory')
+
+  if (storedData) {
+    const parsedData = JSON.parse(storedData)
+    return parsedData.id
+  } else {
+    console.log('데이터가 localStorage에 없습니다.')
+    return null
+  }
+}
+
+export default function badge() {
+  const categoryId = getStoredCategoryId()
+  const getSelectedCharacter = (
+    categoryId: number,
+  ): 'water' | 'air' | 'soil' | 'warming' | 'recycle' | 'energy' => {
+    switch (categoryId) {
+      case 1:
+        return 'water'
+      case 2:
+        return 'air'
+      case 3:
+        return 'soil'
+      case 4:
+        return 'warming'
+      case 5:
+        return 'recycle'
+      case 6:
+        return 'energy'
+      default:
+        throw new Error('Invalid categoryId')
+    }
+  }
+
+  const selectedCharacter = getSelectedCharacter(categoryId)
+
   return (
     <div className="relative w-full h-full flex justify-center">
       <Image
@@ -35,5 +72,3 @@ const badge = () => {
     </div>
   )
 }
-
-export default badge

--- a/src/components/common/CategoryField.tsx
+++ b/src/components/common/CategoryField.tsx
@@ -52,7 +52,7 @@ export default function CategoryField(props: CategoryFieldProps) {
             name,
           }),
         )
-        router.push('/')
+        router.push('/badge')
       }
       updateCategoryStatus(name)
     },

--- a/src/components/main/Levelup.tsx
+++ b/src/components/main/Levelup.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Image from 'next/image'
 import RewardText from '../common/RewardText'
 import Button from '../common/Button'
@@ -14,21 +14,28 @@ interface LevelupProps {
   selectedCharacter: keyof typeof characterGroup
   index: number
   level: number
+  isAllCompleted: boolean
 }
 
-function Levelup(props: LevelupProps) {
-  const { onClose, selectedCharacter, index, level } = props
+export default function Levelup(props: LevelupProps) {
+  const { onClose, selectedCharacter, index, level, isAllCompleted } = props
   const character = characterGroup[selectedCharacter] as CharacterData
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="relative w-full max-w-[390px] h-full">
         <Image src={character.background[index]} alt="" fill className="object-cover" />
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <RewardText>{character.levelupText[index]}</RewardText>
+        <div className="cursor-default absolute inset-0 flex flex-col items-center justify-center">
+          <RewardText
+            handleRewardTextClick={() => {
+              if (!isAllCompleted) onClose()
+            }}
+          >
+            {character.levelupText[index]}
+          </RewardText>
         </div>
       </div>
-      {level === 3 && (
+      {level === 3 && !isAllCompleted && (
         <section className="absolute bottom-10 flex gap-3">
           <Button
             width={104}
@@ -36,7 +43,7 @@ function Levelup(props: LevelupProps) {
             fontSize={16}
             backgroundColor="bg-beige"
             color="text-brown"
-            onClick={() => {}}
+            onClick={onClose}
             isMediumFont
           >
             돌아가기
@@ -55,8 +62,36 @@ function Levelup(props: LevelupProps) {
           </Button>
         </section>
       )}
+
+      {level === 3 && isAllCompleted && (
+        <section className="absolute bottom-10 flex gap-3">
+          <Button
+            width={104}
+            height={40}
+            fontSize={16}
+            backgroundColor="bg-beige"
+            color="text-brown"
+            isLink
+            href="/mypage"
+            isMediumFont
+          >
+            마이홈으로
+          </Button>
+          <Button
+            width={145}
+            height={40}
+            fontSize={16}
+            backgroundColor="bg-gray"
+            color="text-light-gray"
+            onClick={() => {
+              alert('모든 주민을 구했습니다!')
+            }}
+            isMediumFont
+          >
+            다른 주민 구하기
+          </Button>
+        </section>
+      )}
     </div>
   )
 }
-
-export default Levelup


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |

<badge 이동>

https://github.com/user-attachments/assets/2d13300f-9e21-4a3e-896b-3ac1de821282

<클리어 후 공유하기 버튼 생성>

https://github.com/user-attachments/assets/1bf6c5ea-95f1-4ef4-ab0e-fac6b2c24ca9

<재로그인 시 공유하기 화면으로>

https://github.com/user-attachments/assets/08575b22-077e-4291-90d4-7e54b0c21679

### 📝 Details

- isAllComplete 변수 만들어서 levelup 화면코드 수정
- auth/callback > is_all_clear 확인 후 경로 이동코드 추가
- categoryField에서 주민버튼 클릭시 /badge로 이동하도록 수정

### ⚠️ 주의사항

- 마지막 주민 클리어 시 버튼 비활성화를 못해서 alert 함수로 막아두었습니다
- badge의 경로를 src/app/badge로 설정했습니다 => 이것 때문인지 모르겠지만, 마이홈에서 뒤로가기를 누르면 마지막으로 봤던 뱃지화면이 뜸

