### PR TITLE
Feature/#90: 유저 관련 이슈 처리

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,4 +1,5 @@
 import { createSupabaseBrowserClient } from '@/utils/client/supabase'
+import { removeLocalStorage } from '@/utils/common/localStorage'
 
 /**
  * 소셜 로그인을 처리하는 함수
@@ -38,5 +39,6 @@ export const onClickLogout = async () => {
   const supabase = createSupabaseBrowserClient()
   const { error } = await supabase.auth.signOut()
   if (error) return console.error('로그아웃에 실패했습니다.', error.message)
+  removeLocalStorage('category')
   window.location.href = '/auth'
 }

--- a/src/apis/category.ts
+++ b/src/apis/category.ts
@@ -84,7 +84,6 @@ export const getCategoryProgressUjin = async (user_id: string): Promise<Category
 
   return data
 }
-
 /**
  * 카테고리 이름으로 ID 반환
  * @param name 카테고리 이름
@@ -96,6 +95,19 @@ export const getCategoryIdByName = async (name: string) => {
   if (error) return console.error('카테고리 ID 조회 실패:', error.message)
   return data[0].id
 }
+
+/**
+ * 카테고리 ID로 카테고리 이름 반환
+ * @param id 카테고리 아이디
+ * @returns 해당 카테고리 이름
+ */
+export const getCategoryNameById = async (id: string | number) => {
+  const { data, error } = await supabase.from('category').select('name').eq('id', id)
+
+  if (error) return console.error('카테고리 이름 조회 실패:', error.message)
+  return data[0].name
+}
+
 /**
  * 새로운 카테고리 진행 데이터 생성
  * @param userId 유저 UUID
@@ -113,7 +125,6 @@ export const createCategoryProgress = async (user_id: string, name: string) => {
   })
 
   if (error) return console.error('카테고리 진행 생성 실패:', error.message)
-  console.log('카테고리 진행 생성 성공')
 }
 
 /**
@@ -128,7 +139,6 @@ export const getCategoryProgressIsCompleted = async (user_id: string) => {
     .from('category_progress')
     .select('is_completed')
     .eq('user_id', user_id)
-  console.log('data', data)
   if (error) console.error('error: ', error.message)
   return data
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -17,6 +17,7 @@ import {
 import { getUserId } from '@/apis/user'
 import { changeComplete, getCategoryProgress } from '@/apis/category'
 import dynamic from 'next/dynamic'
+import { setLocalStorageCategory } from '@/utils/common/localStorage'
 
 // 로딩 컴포넌트를 동적으로 불러오기
 const Loading = dynamic(() => import('@/app/loading'), { ssr: false })
@@ -65,6 +66,7 @@ export default function Page() {
     if (isAllCompleted) {
       console.log('All categories completed!')
     }
+    setLocalStorageCategory('category', 'id', categoryId)
   }, [isAllCompleted])
 
   // 페이지가 로드될 때 유저의 potion 값 불러오기

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -7,13 +7,10 @@ import { useRouter } from 'next/navigation'
 import Loading from '../loading'
 import Button from '@/components/common/Button'
 import CategoryField from '@/components/common/CategoryField'
-import {
-  createCategoryProgress,
-  getCategoryIdByName,
-  getCategoryProgressIsCompleted,
-} from '@/apis/category'
+import { createCategoryProgress, getCategoryProgressIsCompleted } from '@/apis/category'
 import { getUserId } from '@/apis/user'
 import useUserStore from '@/store/useUserStore'
+import { setLocalStorageCategory } from '@/utils/common/localStorage'
 
 export default function ChooseCategory() {
   const { categoryListWithStatus, isLoading } = useUpdatedCategoryList()
@@ -61,13 +58,7 @@ export default function ChooseCategory() {
       setCategoryId(selectedCategory.id)
 
       // localStorage에 categoryName 저장
-      localStorage.setItem(
-        'category',
-        JSON.stringify({
-          id: await getCategoryIdByName(selectCategory),
-          name: selectCategory,
-        }),
-      )
+      setLocalStorageCategory('category', 'name', selectCategory)
 
       // 유저 ID 가져오기 및 Zustand에 저장
       const userId = (await getUserId()) as string

--- a/src/components/common/CategoryField.tsx
+++ b/src/components/common/CategoryField.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import SpotButton from './SpotButton'
 import { Category, CategoryFieldProps } from '@/types/CategoryField'
 import { useEffect, useState, useCallback } from 'react'
-import { getCategoryIdByName } from '@/apis/category'
+import { setLocalStorageCategory } from '@/utils/common/localStorage'
 
 export default function CategoryField(props: CategoryFieldProps) {
   const { categoryList, isClickable = false, onClick, setSelectCategory } = props
@@ -45,13 +45,7 @@ export default function CategoryField(props: CategoryFieldProps) {
       if (setSelectCategory && status !== 'completed') setSelectCategory(name)
       if (!isCategoryClickable(status!)) return
       if (pathname === '/mypage' && status === 'completed') {
-        localStorage.setItem(
-          'viewResultCategory',
-          JSON.stringify({
-            id: await getCategoryIdByName(name),
-            name,
-          }),
-        )
+        setLocalStorageCategory('viewResultCategory', 'name', name)
         router.push('/badge')
       }
       updateCategoryStatus(name)

--- a/src/utils/common/localStorage.ts
+++ b/src/utils/common/localStorage.ts
@@ -1,0 +1,26 @@
+import { getCategoryIdByName, getCategoryNameById } from '@/apis/category'
+
+// GET
+export const getLocalStorage = (target: string) => localStorage.getItem(target)
+
+// SET
+export const setLocalStorage = (target: string, data: any) => {
+  localStorage.setItem(target, JSON.stringify(data))
+}
+
+// SET: 카테고리 정보 로컬스토리지에 담기(category, viewResultCategory)
+export const setLocalStorageCategory = async (
+  saveName: string,
+  existed: 'id' | 'name',
+  data: number | string,
+) => {
+  setLocalStorage(saveName, {
+    id: (existed === 'id' ? data : await getCategoryIdByName(data as string)) as number,
+    name: (existed === 'id' ? await getCategoryNameById(data as number) : data) as string,
+  })
+}
+
+// REMOVE
+export const removeLocalStorage = (target: string) => {
+  localStorage.removeItem(target)
+}


### PR DESCRIPTION
### 🖼️ Screen shot

| 로그인 전| 메인 페이지 접속 | 로그아웃 후 | 
| :-------------: | :-------------: | :-------------: |
| <img src='https://github.com/user-attachments/assets/bdcd8224-6d37-4f88-a8e1-7cfe83e15269' />  | <img src='https://github.com/user-attachments/assets/a16af0af-a186-40a4-a63d-0cdcd1a731e5' />  | <img src='https://github.com/user-attachments/assets/76c6d0e1-dbe5-4fbb-8312-208726366c8d' />  |


### ✅ 작업 내용

- 로컬 스토리지 사용하는 함수들을 `utils/common/localSotrage.ts`에 작성해두었습니다.
  - 제가 사용하는 곳 외에는 건들지 않았으니, 상황보고 변경하거나 그대로 둬도 될 것 같습니다.
- 로그인을 해야지만 메인 페이지에 접근할 수 있기 때문에 메인 페이지에서 카테고리 정보를 로컬 스토리지에 담았습니다.
- 로그아웃 시 카테고리 관련 로컬 스토리지를 지우도록 했습니다.
