### PR TITLE
Feature/#89: 소셜 로그인 및 카테고리 상태 관리 기능 구현

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,3 +1,4 @@
+import useUserStore from '@/store/useUserStore'
 import { createSupabaseBrowserClient } from '@/utils/client/supabase'
 
 /**
@@ -36,7 +37,14 @@ export const onClickKakao = async () => await onClickSocialLogin('kakao')
  */
 export const onClickLogout = async () => {
   const supabase = createSupabaseBrowserClient()
+
   const { error } = await supabase.auth.signOut()
   if (error) return console.error('로그아웃에 실패했습니다.', error.message)
+
+  // zustand user-store 제거
+  const clearUserStore = useUserStore.getState().clearUser
+  clearUserStore()
+  localStorage.removeItem('user-store')
+
   window.location.href = '/auth'
 }

--- a/src/apis/category.ts
+++ b/src/apis/category.ts
@@ -105,7 +105,13 @@ export const getCategoryNameById = async (id: string | number) => {
   const { data, error } = await supabase.from('category').select('name').eq('id', id)
 
   if (error) return console.error('카테고리 이름 조회 실패:', error.message)
-  return data[0].name
+
+  if (!data || data.length === 0) {
+    console.error(`ID ${id}에 해당하는 카테고리가 없습니다.`)
+    return null // 또는 기본값 반환
+  }
+
+  return data[0].name || null // 데이터가 있더라도 name이 없을 경우 null 반환
 }
 
 /**


### PR DESCRIPTION
### 🖼️ Screen shot

https://github.com/user-attachments/assets/15b64697-0ad0-4026-b50b-0c5bbf7c6577

### ✅ 작업 내용

- 로그인 성공 후 `userId` 및 `categoryId`를 Zustand에 저장
- 로그인 상태를 로컬스토리지와 동기화하여 유지

### ⚠️ 주의사항

- 기존에 사용하던 `state` 기반 `userId`, `categoryId` 관리 방식을 제거하고 Zustand를 사용하여 상태 관리로 대체하였습니다.
- 관련된 로직에서 Zustand의 상태`(zustandUserId, zustandCategoryId)`를 활용하도록 변경했습니다.
