### PR TITLE
feat(feature/#93): 마이홈 헤더에 메인으로 가기  추가, 배지 페이지 다시 추가

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,7 +1,7 @@
 'use client'
-
 import React, { useState, useEffect } from 'react'
 import Image from 'next/image'
+import characterGroup from '@/assets/characterData'
 import CharacterSection from '@/components/main/CharacterSection'
 import FooterButtons from '@/components/main/FooterButtons'
 import Levelup from '@/components/main/Levelup'
@@ -16,225 +16,249 @@ import {
 } from '@/apis/main'
 import { getUserId } from '@/apis/user'
 import { changeComplete, getCategoryProgress } from '@/apis/category'
-import { removeLocalStorage, setLocalStorageCategory } from '@/utils/common/localStorage'
-import Loading from '@/app/loading'
-import { CategoryNameEnglish } from '@/types/CategoryField'
-import calculateProgressDetails from '@/utils/main/calculateProgressDetails'
+import dynamic from 'next/dynamic'
+import { setLocalStorageCategory } from '@/utils/common/localStorage'
 import useUserStore from '@/store/useUserStore'
 
-const categoryList = ['water', 'air', 'soil', 'warming', 'recycle', 'energy']
-
-interface MainState {
-  userId: string
-  categoryId: number
-  loading: boolean
-  potion: null | number
-  currentProgress: null | number
-  level: number
-  isEnd: boolean
-  isAllCompleted: boolean
-  isExistedStorage: boolean
-  index: number
-  message: string
-  isShowLevelUp: boolean
-}
+// 로딩 컴포넌트를 동적으로 불러오기
+const Loading = dynamic(() => import('@/app/loading'), { ssr: false })
 
 export default function Page() {
-  const [state, setState] = useState<MainState>({
-    userId: '',
-    categoryId: 1,
-    loading: true,
-    potion: null,
-    currentProgress: null,
-    level: 1,
-    isEnd: false,
-    isAllCompleted: false,
-    isExistedStorage: false,
-    index: 0,
-    message: '',
-    isShowLevelUp: false,
-  })
-  const { userId: zustandUserId, categoryId: zustandCategoryId, setUserId } = useUserStore()
+  // const [userId, setUserId] = useState<string>('')
+  // const [categoryId, setCategoryId] = useState<number>(1)
+  const [loading, setLoading] = useState(true) // 로딩 상태 추가
 
-  const currentCategoryName = categoryList[state.categoryId - 1] as CategoryNameEnglish
+  // 물약 & 경험치
+  const [potion, setPotion] = useState<number | null>(null)
+  const [currentProgress, setCurrentProgress] = useState<number | null>(null)
+  const [level, setLevel] = useState(1)
+  const [isEnd, setIsEnd] = useState(false)
+  const [isAllCompleted, setIsAllCompleted] = useState(false)
+
+  const {
+    userId: zustandUserId,
+    categoryId: zustandCategoryId,
+    setUserId,
+    setCategoryId,
+  } = useUserStore()
+
+  const getSelectedCharacter = (
+    categoryId: number,
+  ): 'water' | 'air' | 'soil' | 'warming' | 'recycle' | 'energy' => {
+    switch (categoryId) {
+      case 1:
+        return 'water'
+      case 2:
+        return 'air'
+      case 3:
+        return 'soil'
+      case 4:
+        return 'warming'
+      case 5:
+        return 'recycle'
+      case 6:
+        return 'energy'
+      default:
+        throw new Error('Invalid categoryId')
+    }
+  }
+
+  // `categoryId`가 로드된 후 선택된 캐릭터 설정
+  const selectedCharacter = zustandCategoryId ? getSelectedCharacter(zustandCategoryId) : null
+
+  const [index, setIndex] = useState(0)
+  const [message, setMessage] = useState('')
+  const [isShowLevelup, setIsShowLevelup] = useState(false)
 
   useEffect(() => {
-    if (state.isAllCompleted) console.log('All categories completed!')
+    if (isAllCompleted) {
+      console.log('All categories completed!')
+    }
+    // setLocalStorageCategory('category', 'id', categoryId)
+    setLocalStorageCategory('category', 'id', zustandCategoryId || 0)
+  }, [isAllCompleted, zustandCategoryId])
 
-    const fetchPotionProgress = async () => {
+  useEffect(() => {
+    if (isAllCompleted) {
+      console.log('All categories completed!')
+    }
+  }, [isAllCompleted])
+
+  // 페이지가 로드될 때 유저의 potion 값 불러오기
+  useEffect(() => {
+    const fetchPotionAndProgress = async () => {
       try {
         let userId: string | null = zustandUserId
-
-        // Zustand에 userId가 없는 경우 API 호출로 로드
         if (!userId) {
+          // Zustand에 userId가 없는 경우 API 호출로 로드
           userId = (await getUserId()) || null
-          if (!userId) throw new Error('유저 ID를 찾을 수 없습니다.')
+          if (!userId) throw new Error('User ID not found')
           setUserId(userId)
         }
 
         let categoryId: number | null = zustandCategoryId
-
-        // Zustand에 categoryId가 없는 경우 API 호출로 로드
         if (!categoryId) {
-          const getCurrentCategoryInfo = await getCategoryProgress(userId)
-          const isClearCategoryInfo = getCurrentCategoryInfo.find(
-            category => !category.is_completed,
-          )
-          if (!isClearCategoryInfo) return setState(prev => ({ ...prev, isAllCompleted: true }))
-          const currentCategoryId = isClearCategoryInfo.category_id
-          setState(prev => ({
-            ...prev,
-            categoryId: currentCategoryId,
-          }))
+          // Zustand에 categoryId가 없는 경우 API 호출로 로드
+          const getCategory = await getCategoryProgress(userId)
+          const incompleteCategory = getCategory.find(category => !category.is_completed)
+          if (!incompleteCategory) {
+            setIsAllCompleted(true)
+            return
+          }
+
+          categoryId = incompleteCategory.category_id
+          setCategoryId(categoryId)
         }
 
-        setLocalStorageCategory('category', 'id', state.categoryId || 0)
+        // 포션 및 진행 상태 로드
+        const initialPoint = await getPotion(userId)
+        const initialProgress = await getProgress(userId, categoryId)
 
-        const localStorageData = JSON.parse(localStorage.getItem('viewResultCategory') as string)
+        if (initialPoint !== null) setPotion(initialPoint)
+        if (initialProgress !== null) {
+          setCurrentProgress(initialProgress)
 
-        // [1] 로컬스토리지에 viewResultCategory 존재O
-        if (localStorageData) {
-          setState(prev => ({
-            ...prev,
-            categoryId: localStorageData.id,
-            index: 2,
-            level: 3,
-            isEnd: true,
-            currentProgress: 200,
-            isExistedStorage: true,
-            loading: false,
-          }))
+          // currentProgress에 따라 초기 level 설정
+          if (initialProgress < 100) {
+            setLevel(1)
+            setIndex(0)
+          } else if (initialProgress >= 100 && initialProgress < 250) {
+            setLevel(2)
+            setIndex(1)
+            setCurrentProgress(initialProgress - 100)
+          } else if (initialProgress >= 250 && initialProgress < 450) {
+            setLevel(3)
+            setIndex(2)
+            setCurrentProgress(initialProgress - 250)
+          } else if (initialProgress === 450) {
+            setIndex(2)
+            setIsEnd(true)
+            setLevel(3)
+            setCurrentProgress(initialProgress - 250)
+          }
         }
-        // [2] 로컬스토리지에 viewResultCategory 존재X
-        else {
-          const currentPoint = await getPotion(userId)
-          const currentProgress = await getProgress(userId, state.categoryId)
-          const { level, index, adjustedProgress } = calculateProgressDetails(
-            currentProgress as number,
-          )
-
-          setState(prev => ({
-            ...prev,
-            categoryId: state.categoryId,
-            potion: currentPoint,
-            level,
-            index,
-            currentProgress: adjustedProgress,
-            loading: false,
-          }))
-        }
-      } catch (error) {
-        console.error(error)
+      } finally {
+        setLoading(false) // 데이터 로딩 완료 후 로딩 상태를 false로 설정
       }
     }
 
-    fetchPotionProgress()
-  }, [state.categoryId])
-
-  const handleUsePotion = async () => {
-    if (!state.potion) return
-    if (state.potion <= 0) return setState(prev => ({ ...prev, message: '물약이 부족해요' }))
-
-    const newPotion = state.potion - 1
-    const newProgress = (state.currentProgress || 0) + 10
-
-    setState(prev => ({ ...prev, potion: newPotion, currentProgress: newProgress }))
-    usePotion(state.userId)
-    upgradeProgress(state.userId, state.categoryId)
-
-    if (newProgress === 100 || newProgress === 150 || newProgress === 200) {
-      setState(prev => ({ ...prev, isShowLevelup: true, currentProgress: 0 }))
-    }
-
-    if (newProgress === 200) {
-      changeComplete(state.userId, state.categoryId)
-      const categories = await getCategoryProgress(state.userId)
-      const allCompleted = categories.every(cat => cat.is_completed)
-      if (allCompleted && categories.length === 6) {
-        await updateIsAllCompleted(state.userId)
-        setState(prev => ({ ...prev, isAllCompleted: true }))
-      }
-    }
-  }
+    fetchPotionAndProgress()
+  }, [zustandUserId, zustandCategoryId, setUserId, setCategoryId])
 
   const handleCloseLevelup = () => {
-    setState(prev => ({
-      ...prev,
-      isShowLevelup: false,
-      level: prev.level < 3 ? prev.level + 1 : prev.level,
-      isEnd: prev.level === 3 ? true : prev.isEnd,
-      index: prev.index + 1,
-    }))
+    setIsShowLevelup(false)
+    if (level < 3) {
+      setLevel(level + 1)
+      setIndex(index + 1)
+    } else {
+      setIsEnd(true)
+    }
   }
 
-  if (state.loading) return <Loading />
+  const handleUsePotion = async () => {
+    setMessage('물약을 사용해서 10hp를 회복했어요!')
+    if (potion !== null && potion > 0) {
+      const newPotion = potion - 1
+      setPotion(newPotion)
+    }
+
+    setTimeout(() => setMessage(''), 500)
+    usePotion(zustandUserId!)
+
+    if (currentProgress !== null) {
+      const newProgress = currentProgress + 10
+      upgradeProgress(zustandUserId!, zustandCategoryId!)
+      setCurrentProgress(newProgress)
+
+      if (level === 1 && newProgress === 100) {
+        setIsShowLevelup(true)
+        setCurrentProgress(0)
+      } else if (level === 2 && newProgress === 150) {
+        setIsShowLevelup(true)
+        setCurrentProgress(0)
+      } else if (level === 3 && newProgress === 200) {
+        setIsShowLevelup(true)
+        changeComplete(zustandUserId!, zustandCategoryId!)
+        const getCategory = await getCategoryProgress(zustandUserId!) // 업데이트된 카테고리 진행 상태 확인
+        const allCompleted = getCategory.every(category => category.is_completed)
+
+        if (allCompleted && getCategory.length === 6) {
+          // 모든 카테고리가 완료되었고 데이터베이스 개수가 6개일 때
+          await updateIsAllCompleted(zustandUserId!)
+          setIsAllCompleted(true) // 상태 업데이트
+        }
+      }
+    }
+  }
+
+  if (loading) {
+    return <Loading /> // 로딩 중에 로딩 컴포넌트를 표시
+  }
 
   return (
     <div className="relative w-full h-full flex justify-center">
-      {currentCategoryName && (
+      {selectedCharacter && (
         <Image
-          src={`/image/character/${currentCategoryName}_${state.level}.svg`}
+          src={characterGroup[selectedCharacter].figure[index]}
           alt=""
           fill
           style={{ objectFit: 'cover' }}
         />
       )}
-      <CharacterSection selectedCharacter={currentCategoryName} index={state.index} />
-      {state.message && (
+      {selectedCharacter && (
+        <CharacterSection selectedCharacter={selectedCharacter} index={index} />
+      )}
+      {message && (
         <div className="font-gothic-m absolute text-light-beige top-2/3 text-lg animate-fadeout">
-          {state.message}
+          {message}
         </div>
       )}
-      {!state.isEnd ? (
+
+      {!isEnd && (
         <FooterButtons
-          currentProgress={state.currentProgress ?? 0}
-          level={state.level}
-          handleUsePotion={handleUsePotion}
-          count={state.potion ?? 0}
+          currentProgress={currentProgress ?? 0}
+          level={level}
+          handleUsePotion={() => {
+            if (potion !== null && potion > 0) {
+              handleUsePotion()
+            } else {
+              setMessage('물약이 부족해요')
+              setTimeout(() => setMessage(''), 500)
+            }
+          }}
+          count={potion ?? 0}
         />
-      ) : (
+      )}
+
+      {isEnd && (
         <div className="absolute bottom-8 space-y-5">
-          <ProgressBar currentProgress={state.currentProgress ?? 0} level={state.level} />
+          <ProgressBar currentProgress={currentProgress ?? 0} level={level} />
           <div>
-            {state.isExistedStorage ? (
-              <Button
-                width={303}
-                height={40}
-                fontSize={16}
-                color="text-medium-brown"
-                backgroundColor="bg-yellow"
-                isLink
-                onClick={() => removeLocalStorage('viewResultCategory')}
-                href={'/mypage'}
-                children={'돌아가기'}
-              />
-            ) : (
-              <Button
-                width={303}
-                height={40}
-                fontSize={16}
-                color="text-medium-brown"
-                backgroundColor="bg-yellow"
-                isLink
-                href={'/category'}
-                children={'다른 주민 구하기'}
-              />
-            )}
+            <Button
+              width={303}
+              height={40}
+              fontSize={16}
+              color="text-medium-brown"
+              backgroundColor="bg-yellow"
+              isLink
+              href="/category"
+              children="다른 주민 구하기"
+            />
           </div>
         </div>
       )}
 
-      {state.isShowLevelUp && (
+      {isShowLevelup && selectedCharacter && (
         <Levelup
-          selectedCharacter={currentCategoryName}
-          index={state.index}
+          selectedCharacter={selectedCharacter}
+          index={index}
           onClose={handleCloseLevelup}
-          level={state.level}
-          isAllCompleted={state.isAllCompleted}
+          level={level}
+          isAllCompleted={isAllCompleted}
         />
       )}
 
-      {state.isAllCompleted && (
+      {isAllCompleted && (
         <div className="absolute bg-cream w-full h-full justify-center items-center flex flex-col space-y-6">
           <p className="font-gothic-b text-brown">주민을 모두 구했습니다!</p>
           <Button
@@ -252,7 +276,4 @@ export default function Page() {
       )}
     </div>
   )
-}
-function getSelectedCharacter(zustandCategoryId: number) {
-  throw new Error('Function not implemented.')
 }

--- a/src/app/badge/page.tsx
+++ b/src/app/badge/page.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import characterGroup from '@/assets/characterData'
+import Button from '@/components/common/Button'
+import ProgressBar from '@/components/common/ProgressBar'
+import CharacterSection from '@/components/main/CharacterSection'
+import { removeLocalStorage } from '@/utils/common/localStorage'
+import Image from 'next/image'
+import React, { useEffect, useState } from 'react'
+
+function badge() {
+  const [categoryId, setCategoryId] = useState<number | null>(null)
+  const [selectedCharacter, setSelectedCharacter] = useState<
+    'water' | 'air' | 'soil' | 'warming' | 'recycle' | 'energy'
+  >('water')
+
+  useEffect(() => {
+    const getStoredCategoryId = (): number | null => {
+      const storedData = localStorage.getItem('viewResultCategory')
+      if (storedData) {
+        const parsedData = JSON.parse(storedData)
+        return parseInt(parsedData.id)
+      } else {
+        console.log('데이터가 localStorage에 없습니다.')
+        window.location.href = '/'
+        return null
+      }
+    }
+
+    const id = getStoredCategoryId()
+    if (id !== null) {
+      setCategoryId(id)
+      setSelectedCharacter(getSelectedCharacter(id))
+    }
+  }, [])
+
+  const getSelectedCharacter = (
+    categoryId: number,
+  ): 'water' | 'air' | 'soil' | 'warming' | 'recycle' | 'energy' => {
+    switch (categoryId) {
+      case 1:
+        return 'water'
+      case 2:
+        return 'air'
+      case 3:
+        return 'soil'
+      case 4:
+        return 'warming'
+      case 5:
+        return 'recycle'
+      case 6:
+        return 'energy'
+      default:
+        throw new Error('Invalid categoryId')
+    }
+  }
+
+  if (!categoryId) {
+    return <div>로딩 중...</div>
+  }
+
+  return (
+    <div className="relative w-full h-full flex justify-center">
+      <Image
+        src={characterGroup[selectedCharacter].figure[2]}
+        alt=""
+        fill
+        style={{ objectFit: 'cover' }}
+      />
+      <CharacterSection selectedCharacter={selectedCharacter} index={3} />
+      <div className="absolute bottom-8 space-y-5">
+        <ProgressBar currentProgress={200} level={3} />
+        <div>
+          <Button
+            width={303}
+            height={40}
+            fontSize={16}
+            color="text-medium-brown"
+            backgroundColor="bg-yellow"
+            isLink
+            onClick={() => removeLocalStorage('viewResultCategory')}
+            href="/mypage"
+            children="돌아가기"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default badge

--- a/src/assets/characterData.ts
+++ b/src/assets/characterData.ts
@@ -1,10 +1,20 @@
 const characterGroup = {
   water: {
+    figure: [
+      '/image/character/water_1.svg',
+      '/image/character/water_2.svg',
+      '/image/character/water_3.svg',
+    ],
+    background: [
+      '/image/background/water_1.svg',
+      '/image/background/water_2.svg',
+      '/image/background/water_3.svg',
+    ],
     dialogues: [
       '이 바닷속이 탁해져서 숨이 턱턱 막히는구먼… 이러다가는 물고기 친구들도 다 떠나버리겠소…',
       '오호, 바닷물이 조금씩 맑아지기 시작하는구먼… 뭔가 큰 변화가 있는 듯하오.',
       '이제 바닷물이 푸르르고 맑구먼, 숨이 이렇게나 편안할 줄이야… 덕분에 바다에 생기가 돌아오게 되었소.',
-      '허허, 자네의 정성이 이렇게 큰 변화를 만들었구려. 참말로 고맙소, 마음 깊이 감사하오.',
+      `허허, 자네의 정성이 이렇게 큰 변화를 만들었구려. 참말로 고맙소, 마음 깊이 감사하오.`,
     ],
     levelupText: [
       '바닷속 쓰레기가 점점 줄고있어~!',
@@ -16,6 +26,16 @@ const characterGroup = {
     nameColor: '#FFFF91',
   },
   air: {
+    figure: [
+      '/image/character/air_1.svg',
+      '/image/character/air_2.svg',
+      '/image/character/air_3.svg',
+    ],
+    background: [
+      '/image/background/air_1.svg',
+      '/image/background/air_2.svg',
+      '/image/background/air_3.svg',
+    ],
     dialogues: [
       '요새 공기가 너무 탁해져서 숨 쉬기 힘들어구리… 나갈 때는 마스크가 필요해',
       '오늘은 공기가 조금 더 맑아진 느낌이야구리! 숨 쉬는 게 살짝 편해진 것 같아서 다행이야구리.',
@@ -32,6 +52,16 @@ const characterGroup = {
     nameColor: '#4A2615',
   },
   soil: {
+    figure: [
+      '/image/character/soil_1.svg',
+      '/image/character/soil_2.svg',
+      '/image/character/soil_3.svg',
+    ],
+    background: [
+      '/image/background/soil_1.svg',
+      '/image/background/soil_2.svg',
+      '/image/background/soil_3.svg',
+    ],
     dialogues: [
       '아이고… 땅이 엉망이 됐네. 흙이 이렇게 나빠져서는 무가 자랄 틈이 없구만…',
       '에구, 이번엔 무가 썩었네... 흙이 아직 완전히 회복되지 않은가 보네. 제대로 된 무를 언제쯤 볼 수 있으려나…',
@@ -48,6 +78,16 @@ const characterGroup = {
     nameColor: '#A83310',
   },
   warming: {
+    figure: [
+      '/image/character/warming_1.svg',
+      '/image/character/warming_2.svg',
+      '/image/character/warming_3.svg',
+    ],
+    background: [
+      '/image/background/warming_1.svg',
+      '/image/background/warming_2.svg',
+      '/image/background/warming_3.svg',
+    ],
     dialogues: [
       '아이고야… 날이 너무 따뜻해져서 내 몸이 줄줄 녹아내리는구먼. 이러다간 눈사람 구실도 못 하겠어…',
       '어라? 요 며칠 좀 서늘해진 것 같구먼! 덕분에 내 몸도 조금 단단해진 기분이라, 이거 희망이 보이는디!',
@@ -65,6 +105,16 @@ const characterGroup = {
   },
 
   recycle: {
+    figure: [
+      '/image/character/recycle_1.svg',
+      '/image/character/recycle_2.svg',
+      '/image/character/recycle_3.svg',
+    ],
+    background: [
+      '/image/background/recycle_1.svg',
+      '/image/background/recycle_2.svg',
+      '/image/background/recycle_3.svg',
+    ],
     dialogues: [
       '쓰레기들이 아무렇게나 널브러져 있으이, 여가 시장통인지 쓰레기장인지 헷갈린다니까예…',
       '좀 깨끗해진 거 같지예? 길도 한결 말끔해진 기분이다 아이가. 누가 고생을 하고 있는 기라예~',
@@ -81,6 +131,16 @@ const characterGroup = {
     nameColor: '#FAFECF',
   },
   energy: {
+    figure: [
+      '/image/character/energy_1.svg',
+      '/image/character/energy_2.svg',
+      '/image/character/energy_3.svg',
+    ],
+    background: [
+      '/image/background/energy_1.svg',
+      '/image/background/energy_2.svg',
+      '/image/background/energy_3.svg',
+    ],
     dialogues: [
       '흐음… 저 반짝이는 별들을 관찰하려 했건만, 도시 불빛이 너무도 강렬하군요…',
       '어라? 오늘은 저 먼 별들이 희미하게 모습을 드러내기 시작했군요. 아주 흥미로운 변화입니다!',

--- a/src/components/common/CategoryField.tsx
+++ b/src/components/common/CategoryField.tsx
@@ -46,7 +46,7 @@ export default function CategoryField(props: CategoryFieldProps) {
       if (!isCategoryClickable(status!)) return
       if (pathname === '/mypage' && status === 'completed') {
         setLocalStorageCategory('viewResultCategory', 'name', name)
-        router.push('/')
+        router.push('/badge')
       }
       updateCategoryStatus(name)
     },

--- a/src/components/common/header/Dropdown.tsx
+++ b/src/components/common/header/Dropdown.tsx
@@ -13,6 +13,10 @@ export default function Dropdown() {
       onClick: () => router.push('/mypage/edit'),
     },
     {
+      text: '메인으로 가기',
+      onClick: () => router.push('/'),
+    },
+    {
       text: '로그아웃',
       onClick: () => {
         console.log('로그아웃!')


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
| <img src="https://github.com/user-attachments/assets/0fa59323-9586-4b9a-b2a6-48601e3ec9e2" />  |




### ✅ 작업 내용

- 마이홈에서 클리어한 카테고리를 클릭하면 배지 페이지로 이동하도록 다시 수정했습니다.
- 마이홈 헤더에 '메인으로 가기' 추가했습니다.

### 📝 Details

메인 페이지에서 카테고리가 계속 바뀌는 문제가 있었습니다. 이건 디폴트 카테고리를 1로 설정했기 때문에 카테고리가 1과 다른 것(ex. 3)이 계속 번갈아 보이는 문제였고, 이걸 해결하면 물약을 못먹이는 등 다양한 문제가 발생해서 그냥 다시 배지 페이지를 추가하는 쪽으로 수정했습니다.

배지 페이지에서 돌아가기 버튼을 누르면 viewResultCategory를 로컬스토리지에서 삭제하고, 마이홈에서 뒤로가기 버튼을 눌렀을 때는 배지 페이지로 이동하지만, 로컬스토리지에 값이 없기 때문에 메인으로 돌아가도록 수정해두었습니다.

### 💬 Thinking

- 하하핳 제가 테스트하던 계정이 해탈한이었어서 카테고리가 변하는 문제는 몰랐네요... 괜히 밤샌거 같네여