### PR TITLE
fix: 로컬스토리지 관련 처리

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -74,8 +74,10 @@ export default function Page() {
     if (isAllCompleted) {
       console.log('All categories completed!')
     }
-    // setLocalStorageCategory('category', 'id', categoryId)
-    setLocalStorageCategory('category', 'id', zustandCategoryId || 0)
+    const name = ['수질오염', '대기오염', '토양오염', '지구온난화', '분리수거', '에너지 절약'][
+      zustandCategoryId as number
+    ]
+    localStorage.setItem('category', JSON.stringify({ id: zustandCategoryId, name: name }))
   }, [isAllCompleted, zustandCategoryId])
 
   useEffect(() => {
@@ -200,7 +202,6 @@ export default function Page() {
   if (loading) {
     return <Loading /> // 로딩 중에 로딩 컴포넌트를 표시
   }
-
   return (
     <div className="relative w-full h-full flex justify-center">
       {selectedCharacter && (

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -58,7 +58,7 @@ export default function ChooseCategory() {
       setCategoryId(selectedCategory.id)
 
       // localStorage에 categoryName 저장
-      setLocalStorageCategory('category', 'name', selectCategory)
+      localStorage.setItem('category', JSON.stringify({ id: selectedCategory.id, name: name }))
 
       // 유저 ID 가져오기 및 Zustand에 저장
       const userId = (await getUserId()) as string

--- a/src/components/common/CategoryField.tsx
+++ b/src/components/common/CategoryField.tsx
@@ -45,7 +45,18 @@ export default function CategoryField(props: CategoryFieldProps) {
       if (setSelectCategory && status !== 'completed') setSelectCategory(name)
       if (!isCategoryClickable(status!)) return
       if (pathname === '/mypage' && status === 'completed') {
-        setLocalStorageCategory('viewResultCategory', 'name', name)
+        console.log('name', name)
+        const nameList = [
+          '수질오염',
+          '대기오염',
+          '토양오염',
+          '지구온난화',
+          '분리수거',
+          '에너지 절약',
+        ]
+        const categoryId = nameList.indexOf(name) + 1
+        localStorage.setItem('viewResultCategory', JSON.stringify({ id: categoryId, name: name }))
+
         router.push('/badge')
       }
       updateCategoryStatus(name)


### PR DESCRIPTION
### ✅ 작업 내용

- 로컬스토리지 `category` `id: 0, name:null` 이슈 처리
- 로컬스토리지 `viewResultCategory`에 `id` 안 담기는 이슈 처리
