### PR TITLE
image(feature/#43): levelup의 이미지 인덱스 수정

### DIFF
--- a/src/components/main/Levelup.tsx
+++ b/src/components/main/Levelup.tsx
@@ -24,7 +24,7 @@ export default function Levelup(props: LevelupProps) {
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="relative w-full max-w-[390px] h-full">
         <Image
-          src={`/image/background/${selectedCharacter}_${index}.svg`}
+          src={`/image/background/${selectedCharacter}_${index + 1}.svg`}
           alt=""
           fill
           className="object-cover"


### PR DESCRIPTION
### ✅ 작업 내용
<img width="345" alt="스크린샷 2024-12-16 오후 8 27 46" src="https://github.com/user-attachments/assets/e06b221c-b3f4-4d94-b792-8afa7a1ec7fa" />

- 1단계 화면
- 인덱스가 하나씩 밀려서 수정했습니다
